### PR TITLE
Configurable ck-editor

### DIFF
--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -20,6 +20,11 @@ class CKEditorWidget(forms.Textarea):
             )
         except AttributeError:
             raise ImproperlyConfigured("django-ckeditor requires CKEDITOR_MEDIA_PREFIX setting.")
+
+    def __init__(self, toolbar="Full", *args, **kwargs):
+        '''You can set the toolbar to Basic or Full.'''
+        self.toolbar = toolbar
+        super(CKEditorWidget, self).__init__(*args, **kwargs)
     
     def render(self, name, value, attrs={}):
         if value is None: value = ''
@@ -29,7 +34,7 @@ class CKEditorWidget(forms.Textarea):
             CKEDITOR.replace("%s",
                 {
                     skin: "v2",
-                    toolbar : "Full",
+                    toolbar : "%s",
                     height:"291", 
                     width:"618",
                     filebrowserUploadUrl : "%s",
@@ -38,4 +43,4 @@ class CKEditorWidget(forms.Textarea):
                     filebrowserWindowHeight : '747'
                 }
             );
-        </script>''' % (flatatt(final_attrs), conditional_escape(force_unicode(value)), final_attrs['id'], reverse('ckeditor_upload'), reverse('ckeditor_browse')))
+        </script>''' % (flatatt(final_attrs), conditional_escape(force_unicode(value)), final_attrs['id'], self.toolbar, reverse('ckeditor_upload'), reverse('ckeditor_browse')))


### PR DESCRIPTION
I've modified the ck-editor to allow specifying the type of toolbar the user wants displayed on a given instance of the widget.

The only problem is that it may be backwards-incompatible with anyone who is passing positional arguments into the widget constructor. It'd be nice if Python 2.x had keyword only arguments, but I don't know of any other way to solve this.
