### PR TITLE
overriding RichTextFormField fix

### DIFF
--- a/ckeditor/fields.py
+++ b/ckeditor/fields.py
@@ -17,5 +17,6 @@ class RichTextFormField(forms.fields.Field):
     widget = CKEditorWidget
 
     def __init__(self, *args, **kwargs):
-        kwargs.update({'widget': CKEditorWidget})
+        defaults = {'widget': CKEditorWidget}
+        defaults.update(kwargs)
         super(RichTextFormField, self).__init__(*args, **kwargs)


### PR DESCRIPTION
Couldn't override as the CKEditor widget always overwrites whatever was specified in kwargs.
