### PR TITLE
Repetitive widget settings overriding bug fix

### DIFF
--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -42,7 +42,7 @@ class CKEditorWidget(forms.Textarea):
     def __init__(self, config_name='default', *args, **kwargs):
         super(CKEditorWidget, self).__init__(*args, **kwargs)
         # Setup config from defaults.
-        self.config = DEFAULT_CONFIG
+        self.config = dict(DEFAULT_CONFIG)
 
         # Try to get valid config from settings.
         configs = getattr(settings, 'CKEDITOR_CONFIGS', None)


### PR DESCRIPTION
Because you have the most usable fork of the main project and a bug that I have come across have not still been fixed within I pushed the fix. The bug can be seen if you have 2 or more ck editor settings (one for blogs - default and one for forum posts - bbcode for example). DEFAULT_SETTINGS is assigned as the widget settings and later updated which cause in place change of original DEFAULT_SETTINGS. My fix is to copy actual DEFAULT_SETTINGS into widget settings. The later update is performed on the new copy and original settings remain unchanged.
