### PR TITLE
Use Pillow instead of PIL

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+next
+----
+#. Use Pillow instead of PIL since it builds on all systems.
+
 3.6.2
 -----
 #. Include CKEditor version 3.6.2.

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,8 @@ setup(
     author_email='shaunsephton@gmail.com',
     url='http://github.com/shaunsephton/django-ckeditor',
     packages = find_packages(exclude=['project',]),
-    dependency_links = [
-        'http://dist.plone.org/thirdparty/',
-    ],
     install_requires = [
-        'PIL',
+        'Pillow',
     ],
     include_package_data=True,
     test_suite="setuptest.SetupTestSuite",


### PR DESCRIPTION
Plone itself has moved to Pillow. PIL stopped working on some x86_64 servers recently and rebuilding fails.
