### PR TITLE
Fixing trouble with backward slashes in windows

### DIFF
--- a/ckeditor/views.py
+++ b/ckeditor/views.py
@@ -78,7 +78,7 @@ def get_media_url(path):
     # Break url into a list.
     url_parts = list(urlparse(url))
     # Replace two or more slashes with a single slash.
-    url_parts[2] = re.sub('\/+', '/', url_parts[2])
+    url_parts[2] = re.sub('[\\\/]+', '/', url_parts[2])
     # Reconstruct the url.
     url = urlunparse(url_parts)
 


### PR DESCRIPTION
Fix "CKEditor image upload does not work in windows". Both slashes "/" and reverse slash "\" should be replaced.
