### PR TITLE
Update urls.py

### DIFF
--- a/ckeditor/urls.py
+++ b/ckeditor/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns(
     '',


### PR DESCRIPTION
django.conf.urls.defaults is deprecated; use django.conf.urls instead

django 1.5.1
