### PR TITLE
Remove deprecation warning for django.conf.urls.defaults

### DIFF
--- a/ckeditor/urls.py
+++ b/ckeditor/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns(
     '',


### PR DESCRIPTION
Removed .defaults which causes this warning: DeprecationWarning: django.conf.urls.defaults is deprecated; use django.conf.urls instead
