### PR TITLE
Fixed deprecation warning in import of django.conf.urls.defaults

### DIFF
--- a/ckeditor/urls.py
+++ b/ckeditor/urls.py
@@ -1,4 +1,9 @@
-from django.conf.urls.defaults import patterns, url
+import django
+
+if float("%d.%d"%(django.VERSION[0],django.VERSION[1])) < 1.5:
+    from django.conf.urls.defaults import patterns,url
+else:    
+    from django.conf.urls import patterns,url
 
 urlpatterns = patterns(
     '',


### PR DESCRIPTION
Fixed issue with deprecation warning with version of Django => 1.5

Added back compatibility.
