### PR TITLE
Fixed broken path in css

### DIFF
--- a/ckeditor/static/ckeditor/galleriffic/css/galleriffic-5.css
+++ b/ckeditor/static/ckeditor/galleriffic/css/galleriffic-5.css
@@ -55,7 +55,7 @@ div.loader {
 	position: absolute;
 	top: 0;
 	left: 0;
-	background-image: url('images/loader.gif');
+	background-image: url('loader.gif');
 	background-repeat: no-repeat;
 	background-position: center;
 }


### PR DESCRIPTION
Django CachedStaticFilesStorage breaks if a css file has a broken url
