### PR TITLE
Init the editor when the DOM is fully loaded if CKEDITOR is not defined

### DIFF
--- a/ckeditor/templates/ckeditor/widget.html
+++ b/ckeditor/templates/ckeditor/widget.html
@@ -1,4 +1,10 @@
 <p><textarea{{ final_attrs|safe }}>{{ value }}</textarea></p>
 <script type="text/javascript">
-    CKEDITOR.replace("{{ id }}", {{ config|safe }});
+    if (typeof CKEDITOR == "undefined") {
+        $( document ).ready(function() {
+            CKEDITOR.replace("{{ id }}", {{ config|safe }});
+        });
+    } else {
+        CKEDITOR.replace("{{ id }}", {{ config|safe }});
+    }
 </script>


### PR DESCRIPTION
In the CKEditorWidget template (ckeditor/widget.html), the editor is initialized just after the `textarea` tag. This works fine with the Django admin (where jQuery is loaded before the HTML declaration of the Ckeditor widget), but it will not work with non-admin templates where all the JS stuff can be done inside a Django template `block` tag at the bottom of the page.

This patch fixes the problem by delaying the replacement of `textarea` elements with CKEditor instances if the global `CKEDITOR` object is not available (in this case, these operations will be done when the DOM is fully loaded). If `CKEDITOR` is available, the replacement process is not delayed (current behavior).
