### PR TITLE
Update urls.py

### DIFF
--- a/ckeditor/urls.py
+++ b/ckeditor/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns(
     '',


### PR DESCRIPTION
Fixed call to deprecated function django.conf.urls.defaults. Now is django.conf.urls. (Fix for Django 1.4+)
