### PR TITLE
Update urls.py

### DIFF
--- a/ckeditor/urls.py
+++ b/ckeditor/urls.py
@@ -1,4 +1,8 @@
-from django.conf.urls.defaults import patterns, url
+import django
+if django.VERSION[0:2] >= (1, 4):
+    from django.conf.urls import patterns, url
+else:
+    from django.conf.urls.defaults import patterns, url
 
 urlpatterns = patterns(
     '',


### PR DESCRIPTION
Updated urls.py import statement because django.conf.urls.defaults is deprecated since django 1.6
