### PR TITLE
Update urls.py

### DIFF
--- a/ckeditor/urls.py
+++ b/ckeditor/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import *
 
 urlpatterns = patterns(
     '',


### PR DESCRIPTION
Removed deprecated urls.default. Causing ckeditor to break with django 1.6
