### PR TITLE
fields.py updated to make it compatible with Django 1.7

### DIFF
--- a/ckeditor/fields.py
+++ b/ckeditor/fields.py
@@ -4,7 +4,7 @@ from django import forms
 from ckeditor.widgets import CKEditorWidget
 
 
-class RichTextField(models.Field):
+class RichTextField(models.TextField):
     def __init__(self, *args, **kwargs):
         self.config_name = kwargs.pop("config_name", "default")
         self.extra_plugins = kwargs.pop("extra_plugins", [])
@@ -22,7 +22,7 @@ class RichTextField(models.Field):
         return super(RichTextField, self).formfield(**defaults)
 
 
-class RichTextFormField(forms.fields.Field):
+class RichTextFormField(forms.fields.CharField):
     def __init__(self, config_name='default', extra_plugins=None, external_plugin_resources=None, *args, **kwargs):
         kwargs.update({'widget': CKEditorWidget(config_name=config_name, extra_plugins=extra_plugins, external_plugin_resources=external_plugin_resources)})
         super(RichTextFormField, self).__init__(*args, **kwargs)


### PR DESCRIPTION
This was necessary due to the fact that `init()` method from `forms.fields.Field` takes no "max_length" paramater. Yet, the `formfield()` method from `models.TextField` for `RichTextField` was adding this parameter (check out line 1853 in `django.db.models.fields.__init__.py`).

Replacing `models.TextField` with `models.Field` made this issue disappear.

Tested with django-1.7b1
