### PR TITLE
Fix ckeditor-init.js by giving it access to a valid jQuery instance, along with other minor changes to ckeditor-init.js

### DIFF
--- a/ckeditor/static/ckeditor/ckeditor-init.js
+++ b/ckeditor/static/ckeditor/ckeditor-init.js
@@ -1,20 +1,23 @@
-$(function() {
+;(function() {
+  var $ = $ || django.jQuery;
+  $(function() {
     initialiseCKEditor();
     initialiseCKEditorInInlinedForms();
 
     function initialiseCKEditorInInlinedForms() {
-        $(".add-row a, .grp-add-handler").click(function () {
-            initialiseCKEditor();
-            return true;
-        });
+      $(document).on("click", ".add-row a, .grp-add-handler", function () {
+        initialiseCKEditor();
+        return true;
+      });
     }
-});
 
-function initialiseCKEditor() {
-    $('textarea[data-type=ckeditortype]').each(function(){
+    function initialiseCKEditor() {
+      $('textarea[data-type=ckeditortype]').each(function(){
         if($(this).data('processed') == "0" && $(this).attr('id').indexOf('__prefix__') == -1){
-            $(this).data('processed',"1");
-            CKEDITOR.replace($(this).attr('id'), $(this).data('config'));
+          $(this).data('processed',"1");
+          CKEDITOR.replace($(this).attr('id'), $(this).data('config'));
         }
-    });
-}
+      });
+    };
+  });
+}());


### PR DESCRIPTION
fixes #13 . Previously ckeditor-init.js failed to properly run as '$' was undefined. The fix is to use django's jQuery instance if '$' is undefined. 

Also, I replaced the .click() with a .on() because I was running into issues with the event being attached before all elements had been placed. This is particularly an issue for users of django-nested-inlines.
#### Changes:
- Set $ to django.jQuery if $ not defined
- organize ckeditor-init.js
- replace .click(...) with delegated .on(...) in case elements do not exist when code is run
