### PR TITLE
Added lazy JSON encoder in order to support i18n in CKEditor settings

### DIFF
--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -8,10 +8,19 @@ from django.utils.encoding import force_text
 from django.utils.translation import get_language
 from django.core.exceptions import ImproperlyConfigured
 from django.forms.util import flatatt
-import json
+
+from django.utils.functional import Promise
+from django.utils.encoding import force_text
+from django.core.serializers.json import DjangoJSONEncoder
+
+class LazyEncoder(DjangoJSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Promise):
+            return force_text(obj)
+        return super(LazyEncoder, self).default(obj)
 
 
-json_encode = json.JSONEncoder().encode
+json_encode = LazyEncoder().encode
 
 DEFAULT_CONFIG = {
     'skin': 'moono',


### PR DESCRIPTION
A LazyEncoder has been implemented based on Django's `DjangoJSONEncoder`, rather than `json.JSONEncoder`, as described [here](https://docs.djangoproject.com/en/dev/topics/serialization/#serialization-formats-json).

This allows us to use `ugettext_lazy` (and other lazy functions) in `settings.py` which adds the possibility to localize strings for use in the `CKEDITOR_CONFIGS` settings etc.

**Example**

```
from django.utils.translation import ugettext_lazy as _

CKEDITOR_CONFIGS = {
  'default': {
    'stylesSet': [
      { 'name': _('Lead') , 'element': 'p', 'attributes': { 'class': 'lead' } },
      ...
    ]
    ...
  }
```
