### PR TITLE
Handle case where ckeditor-init.js is run with jQuery < 1.7

### DIFF
--- a/ckeditor/static/ckeditor/ckeditor-init.js
+++ b/ckeditor/static/ckeditor/ckeditor-init.js
@@ -11,7 +11,7 @@
           return true;
         });
       } catch (e) {
-        $(document).live(".add-row a, .grp-add-handler", "click",  function () {
+        $(document).delegate(".add-row a, .grp-add-handler", "click",  function () {
           initialiseCKEditor();
           return true;
         });


### PR DESCRIPTION
If the $().on() fails (as it will in jQuery < 1.7), run the $().delegate() equivalent.
