### PR TITLE
Provide Link and Unlink buttons in default config

### DIFF
--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -29,6 +29,7 @@ DEFAULT_CONFIG = {
     ],
     'toolbar_Full': [
         ['Styles', 'Format', 'Bold', 'Italic', 'Underline', 'Strike', 'SpellChecker', 'Undo', 'Redo'],
+        [ 'Link','Unlink','Anchor'],
         ['Image', 'Flash', 'Table', 'HorizontalRule'],
         ['TextColor', 'BGColor'],
         ['Smiley', 'SpecialChar'], ['Source'],


### PR DESCRIPTION
The Default config lacks the basic functionality of inserting links.
This adds these buttons in the default toolbar configuration.
