### PR TITLE
Restore external-plugin-resources handling.

### DIFF
--- a/ckeditor/static/ckeditor/ckeditor-init.js
+++ b/ckeditor/static/ckeditor/ckeditor-init.js
@@ -29,6 +29,9 @@
       $('textarea[data-type=ckeditortype]').each(function(){
         if($(this).data('processed') == "0" && $(this).attr('id').indexOf('__prefix__') == -1){
           $(this).data('processed',"1");
+          $($(this).data('external-plugin-resources')).each(function(){
+              CKEDITOR.plugins.addExternal(this[0], this[1], this[2]);
+          });
           CKEDITOR.replace($(this).attr('id'), $(this).data('config'));
         }
       });

--- a/ckeditor/templates/ckeditor/widget.html
+++ b/ckeditor/templates/ckeditor/widget.html
@@ -1,3 +1,3 @@
 <div class="django-ckeditor-widget" data-field-id="{{id}}" style="display: inline-block;">
-    <textarea{{ final_attrs|safe }} data-processed="0" data-config='{{config|safe}}' data-id="{{id}}" data-type="ckeditortype">{{ value }}</textarea>
+    <textarea{{ final_attrs|safe }} data-processed="0" data-config='{{config|safe}}' data-external-plugin-resources='{{external_plugin_resources|safe}}' data-id="{{id}}" data-type="ckeditortype">{{ value }}</textarea>
 </div>

--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -107,10 +107,13 @@ class CKEditorWidget(forms.Textarea):
         if not self.config.get('language'):
             self.config['language'] = get_language()
 
+        # Force to text to evaluate possible lazy objects
+        external_plugin_resources = [[force_text(a), force_text(b), force_text(c)] for a, b, c in self.external_plugin_resources]
+
         return mark_safe(render_to_string('ckeditor/widget.html', {
             'final_attrs': flatatt(final_attrs),
             'value': conditional_escape(force_text(value)),
             'id': final_attrs['id'],
             'config': json_encode(self.config),
-            'external_plugin_resources' : self.external_plugin_resources
+            'external_plugin_resources' : json_encode(external_plugin_resources)
         }))


### PR DESCRIPTION
In the django-ckeditor-updated fork I had contributed a way to add "External Plugin Resources" via a RichTextField parameter. Since this fork got merged, this did not work anymore. I've now adapted my changes to the new editor initialization approach based on ckeditor-init.js.