### PR TITLE
Fix deprecation warning introduced in Django 1.7

### DIFF
--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -7,7 +7,12 @@ from django.utils.html import conditional_escape
 from django.utils.encoding import force_text
 from django.utils.translation import get_language
 from django.core.exceptions import ImproperlyConfigured
-from django.forms.util import flatatt
+try:
+    # Django >=1.7
+    from django.forms.utils import flatatt
+except ImportError:
+    # Django <1.7
+    from django.forms.util import flatatt
 
 from django.utils.functional import Promise
 from django.utils.encoding import force_text


### PR DESCRIPTION
Django 1.7 renamed django.forms.util to django.forms.utils. In order to silence the Deprecation warning a try-except block is needed.