### PR TITLE
add small image search field

### DIFF
--- a/ckeditor/forms.py
+++ b/ckeditor/forms.py
@@ -1,0 +1,4 @@
+from django import Forms
+
+class SearchForm(forms.Form):
+    q = forms.CharField(label='Search files')

--- a/ckeditor/templates/browse.html
+++ b/ckeditor/templates/browse.html
@@ -39,7 +39,7 @@
                 <div id="search">
                     <form action="" method="post">
                         {% csrf_token %}
-                        <label>Search files&nbsp;<input type="text" name="q"></label>
+                        {{ form }}
                     </form>
                 </div>
                 <div id="thumbs" class="navigation">

--- a/ckeditor/templates/browse.html
+++ b/ckeditor/templates/browse.html
@@ -36,6 +36,12 @@
                     </div>
                     <div id="caption" class="caption-container"></div>
                 </div>
+                <div id="search">
+                    <form action="" method="post">
+                        {% csrf_token %}
+                        <label>Search files&nbsp;<input type="text" name="q"></label>
+                    </form>
+                </div>
                 <div id="thumbs" class="navigation">
                     <ul class="thumbs noscript">
                         {% for file in files %}

--- a/ckeditor/views.py
+++ b/ckeditor/views.py
@@ -149,7 +149,10 @@ def browse(request):
         form = SearchForm(request.POST)
         if form.is_valid():
             files = filter(lambda d: form.cleaned_data.get('q', '').lower() in d['visible_filename'].lower(), files)
+    else:
+        form = SearchForm()
     context = RequestContext(request, {
         'files': files,
+        'form': form
     })
     return render_to_response('browse.html', context)

--- a/ckeditor/views.py
+++ b/ckeditor/views.py
@@ -12,6 +12,7 @@ from django.template import RequestContext
 
 from ckeditor import image_processing
 from ckeditor import utils
+from ckeditor.forms import SearchForm
 
 
 def get_upload_filename(upload_name, user):
@@ -144,8 +145,10 @@ def is_image(path):
 
 def browse(request):
     files = get_files_browse_urls(request.user)
-    if request.POST:
-        files = filter(lambda d: request.POST.get('q', '').lower() in d['visible_filename'].lower(), files)
+    if request.method == 'POST':
+        form = SearchForm(request.POST)
+        if form.is_valid():
+            files = filter(lambda d: form.cleaned_data.get('q', '').lower() in d['visible_filename'].lower(), files)
     context = RequestContext(request, {
         'files': files,
     })

--- a/ckeditor/views.py
+++ b/ckeditor/views.py
@@ -143,7 +143,10 @@ def is_image(path):
 
 
 def browse(request):
+    files = get_files_browse_urls(request.user)
+    if request.POST:
+        files = filter(lambda d: request.POST.get('q', '').lower() in d['visible_filename'].lower(), files)
     context = RequestContext(request, {
-        'files': get_files_browse_urls(request.user),
+        'files': files,
     })
     return render_to_response('browse.html', context)


### PR DESCRIPTION
When django-ckeditor is used in a website with regular updates, frequently the image directory gets so crowded that it is rather difficult find a desired image in the gallery (often resulting in old images being uploaded again and again). Adding a simple search form to the browse() view solves this problem in great way.