### PR TITLE
Changed non-image file upload behavior.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -209,7 +209,7 @@ django-ckeditor send by default the following ckeditor plugins, however, not all
 
 Restricting file upload
 -----------------------
-#. To restrict file types you can upload check ckeditor_uploader.views.ImageUploadView. There are two interesting methods: _verify_file and _on_verification_failure. You can create your own view that inherits this one and overrides those or other methods. Then in your urls.py set your view to point to the ``upload/`` url.
+#. To restrict upload functionality to image files only, add ``CKEDITOR_ALLOW_NONIMAGE_FILES = False`` in your settings.py file. Currently non-image files are allowed by default.
 
 #. By default the upload and browse URLs use staff_member_required decorator - ckeditor_uploader/urls.py - if you want other decorators just insert two urls found in that urls.py and not include it.
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -65,4 +65,4 @@
            },
        }
 
-
+4. To restrict upload functionality to image files only, add ``CKEDITOR_ALLOW_NONIMAGE_FILES = False`` in your settings.py file. Currently non-image files are allowed by default.


### PR DESCRIPTION
I tried to add the image upload handling by ``_verify_file`` function, but for some reasons it was working as expected.

Now you can simply add ``CKEDITOR_ALLOW_NONIMAGE_FILES = False`` in the settings.py file and get an 'Invalid file' error if a non-image file is uploaded.

I also fixed a potential XSS threat by escaping the GET parameter which was directly used. 