### PR TITLE
Update views.py for file browsing files

### DIFF
--- a/ckeditor_uploader/views.py
+++ b/ckeditor_uploader/views.py
@@ -139,6 +139,7 @@ def get_files_browse_urls(user=None):
                     visible_filename = visible_filename[0:19] + '...'
         else:
             thumb = src
+            visible_filename = os.path.split(filename)[1]
         files.append({
             'thumb': thumb,
             'src': src,


### PR DESCRIPTION
Modified the code in order to allocate a visible_filename to files, even if the 'CKEDITOR_IMAGE_BACKEND' is None. WIthout allocating a value to "visible_filename", you couldn't browse, with the search form, through the files because an error ('NoneType' object has no attribute 'lower') appear and make it crash.

French speaker here, sorry for my terrible english. Don't hesitate to ask me more explanations.