### PR TITLE
Do not require the q field in form

### DIFF
--- a/ckeditor_uploader/forms.py
+++ b/ckeditor_uploader/forms.py
@@ -4,4 +4,4 @@ from django import forms
 
 
 class SearchForm(forms.Form):
-    q = forms.CharField(label='Search files')
+    q = forms.CharField(label='Search files', required=False)


### PR DESCRIPTION
This allows to clear out a search by submitting the empty form.
