### PR TITLE
Added setting for suppressing the date as well as the user 

### DIFF
--- a/ckeditor_uploader/utils.py
+++ b/ckeditor_uploader/utils.py
@@ -13,14 +13,19 @@ from django.utils.encoding import force_text
 
 # Non-image file icons, matched from top to bottom
 fileicons_path = '{0}/file-icons/'.format(getattr(settings, 'CKEDITOR_FILEICONS_PATH', '/static/ckeditor'))
-CKEDITOR_FILEICONS = getattr(settings, 'CKEDITOR_FILEICONS', [
-    ('\.pdf$', fileicons_path + 'pdf.png'),
-    ('\.doc$|\.docx$|\.odt$', fileicons_path + 'doc.png'),
-    ('\.txt$', fileicons_path + 'txt.png'),
-    ('\.ppt$', fileicons_path + 'ppt.png'),
-    ('\.xls$', fileicons_path + 'xls.png'),
-    ('.*', fileicons_path + 'file.png'),  # Default
-])
+# This allows adding or overriding the default icons used by Gallerific by getting an additional two-tuple list from 
+# the project settings.  If it does not exist, it is ignored.  If the same file extension exists twice, the settings
+# file version is used instead of the default.
+override_icons = getattr(settings, 'CKEDITOR_FILEICONS', [])
+ckeditor_icons =     [
+        ('\.pdf$', fileicons_path + 'pdf.png'),
+        ('\.doc$|\.docx$|\.odt$', fileicons_path + 'doc.png'),
+        ('\.txt$', fileicons_path + 'txt.png'),
+        ('\.ppt$', fileicons_path + 'ppt.png'),
+        ('\.xls$', fileicons_path + 'xls.png'),
+        ('.*', fileicons_path + 'file.png'),  # Default
+    ]
+CKEDITOR_FILEICONS = override_icons + ckeditor_icons
 
 
 class NotAnImageException(Exception):

--- a/ckeditor_uploader/views.py
+++ b/ckeditor_uploader/views.py
@@ -25,7 +25,11 @@ def get_upload_filename(upload_name, user):
         user_path = ''
 
     # Generate date based path to put uploaded file.
-    date_path = datetime.now().strftime('%Y/%m/%d')
+    # If CKEDITOR_RESTRICT_BY_DATE is True upload file to date specific path.
+    if getattr(settings, 'CKEDITOR_RESTRICT_BY_DATE', True):
+        date_path = datetime.now().strftime('%Y/%m/%d')
+    else:
+        date_path = ''
 
     # Complete upload path (upload_path + date_path).
     upload_path = os.path.join(


### PR DESCRIPTION
Added setting for suppressing the date as well as the user in the uploads.  This allows for a single upload folder, if desired.  Sometimes, a client wants a single folder for uploads in the admin, especially if the total quantity of files is relatively small.  This allows for the same functionality as suppressing the user folder, only with the dates.
