### PR TITLE
Added info about file upload support with widgets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,6 +152,7 @@ Alernatively you can use the included ``CKEditorWidget`` as the widget for a for
 
     admin.site.register(Post, PostAdmin)
 
+**For file upload support use ``CKEditorUploadingWidget`` from ckeditor_uploader.widgets**
 
 Outside of django admin
 ~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I could not understand why file upload is not available. And I found a comment about `RichTextUploadingField`, but did not find about the `CKEditorUploadingWidget`.