### PR TITLE
Use username getter instead of accessing field directly

### DIFF
--- a/ckeditor_uploader/views.py
+++ b/ckeditor_uploader/views.py
@@ -20,7 +20,7 @@ from django.utils.html import escape
 def get_upload_filename(upload_name, user):
     # If CKEDITOR_RESTRICT_BY_USER is True upload file to user specific path.
     if getattr(settings, 'CKEDITOR_RESTRICT_BY_USER', False):
-        user_path = user.username
+        user_path = user.get_username()
     else:
         user_path = ''
 
@@ -96,7 +96,7 @@ def get_image_files(user=None, path=''):
 
     restrict = getattr(settings, 'CKEDITOR_RESTRICT_BY_USER', False)
     if user and not user.is_superuser and restrict:
-        user_path = user.username
+        user_path = user.get_username()
     else:
         user_path = ''
 


### PR DESCRIPTION
This change adds support for custom user models without `username` field when uploading image.

`username` field is not guaranteed in custom usermodels in django. 
Custom user models however can specify another field designated as a username via `USERNAME_FIELD`, whose value is always returned from `get_username()`

Should resolve issue #267 

`get_username()` is available in all supported versions of Django:
https://docs.djangoproject.com/en/1.8/topics/auth/customizing/#django.contrib.auth.models.AbstractBaseUser.get_username