### PR TITLE
Fix tox file to actually test Django 1.10

### DIFF
--- a/ckeditor_demo/demo_application/models.py
+++ b/ckeditor_demo/demo_application/models.py
@@ -2,8 +2,8 @@ from __future__ import absolute_import
 
 from django.db import models
 
-from ckeditor_uploader.fields import RichTextUploadingField
 from ckeditor.fields import RichTextField
+from ckeditor_uploader.fields import RichTextUploadingField
 
 
 class ExampleModel(models.Model):

--- a/ckeditor_demo/urls.py
+++ b/ckeditor_demo/urls.py
@@ -14,7 +14,13 @@ if django.VERSION >= (1, 8):
         url(r'^$', ckeditor_form_view, name='ckeditor-form'),
         url(r'^admin/', include(admin.site.urls)),
         url(r'^ckeditor/', include('ckeditor_uploader.urls')),
-    ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT) + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    ] + static(
+        settings.STATIC_URL,
+        document_root=settings.STATIC_ROOT
+    ) + static(
+        settings.MEDIA_URL,
+        document_root=settings.MEDIA_ROOT
+    )
 else:
     from django.conf.urls import patterns
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,7 @@
 skip_missing_interpreters=True
 envlist=
     py27-coverage-init
-    {py27,py34}-django{18,19,master}
+    {py27,py34}-django{18,19,110}
     py27-{lint,isort,coverage-report}
 
 [testenv]


### PR DESCRIPTION
2082e001aa3151240ccba7477b695b76566070bb missed changing the `djangomaster` tox environment to `django110`.

This also fixes the failures for lint and isort.