### PR TITLE
CKEditorWidget: Go through static() so that the storage's URL generation is used

### DIFF
--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -61,8 +61,8 @@ class CKEditorWidget(forms.Textarea):
             js += (jquery_url, )
         try:
             js += (
-                settings.STATIC_URL + 'ckeditor/ckeditor/ckeditor.js',
-                settings.STATIC_URL + 'ckeditor/ckeditor-init.js',
+                'ckeditor/ckeditor/ckeditor.js',
+                'ckeditor/ckeditor-init.js',
             )
         except AttributeError:
             raise ImproperlyConfigured("django-ckeditor requires \

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ changedir = {toxinidir}
 commands= {envbindir}/coverage run manage.py test ckeditor_demo
 deps=
     coverage==4.2
-    Pillow==3.2.0
+    Pillow==3.4.2
     selenium==2.53.6
     django19: Django>=1.9,<1.10
     django18: Django>=1.8,<1.9
@@ -27,7 +27,7 @@ setenv =
     COVERAGE_FILE = .coverage
 commands =
     coverage erase
-deps = 
+deps =
     coverage==4.2
 
 [testenv:py27-coverage-report]
@@ -36,7 +36,7 @@ setenv =
 commands=
     coverage combine
     coverage report -m
-deps = 
+deps =
     coverage==4.2
 
 


### PR DESCRIPTION
This enables the use of ManifestStaticFilesStorage and far-future expiry headers for staticfiles.

An excerpt from a site in production:

```
<script type="text/javascript" src="/static/admin/js/inlines.min.8ef8b2379896.js"></script>
<script type="text/javascript" src="/static/ckeditor/ckeditor/ckeditor.js"></script>
<script type="text/javascript" src="/static/ckeditor/ckeditor-init.js"></script>
<script type="text/javascript" src="/static/versatileimagefield/js/versatileimagefield.51787809ec9a.js"></script>
```

It would be great if ckeditor's files also had the hash in their filename.

Thanks!