### PR TITLE
Do not try to import south - it's unsuported

### DIFF
--- a/ckeditor/fields.py
+++ b/ckeditor/fields.py
@@ -35,9 +35,3 @@ class RichTextFormField(forms.fields.CharField):
         kwargs.update({'widget': CKEditorWidget(config_name=config_name, extra_plugins=extra_plugins,
                                                 external_plugin_resources=external_plugin_resources)})
         super(RichTextFormField, self).__init__(*args, **kwargs)
-
-try:
-    from south.modelsinspector import add_introspection_rules
-    add_introspection_rules([], ["^ckeditor\.fields\.RichTextField"])
-except ImportError:
-    pass


### PR DESCRIPTION
Because django-ckeditor supports only Django 1.8+ and South is not compatible with these Django versions then we need to remove the south introspection rules.

This will also prevent some errors when upgrade from older versions of Django (pre 1.7) to new Django versions (1.9+) and South is still left in the environment.