### PR TITLE
Updated README for CKEditor URL include

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ Required for using widget with file upload
 
 #. Add CKEditor URL include to your project's ``urls.py`` file::
 
-    (r'^ckeditor/', include('ckeditor_uploader.urls')),
+    url(r'^ckeditor/', include('ckeditor_uploader.urls')),
 
 #. Note that by adding those URLs you add views that can upload and browse through uploaded images. Since django-ckeditor 4.4.6, those views are staff_member_required. If you want a different permission decorator (login_required, user_passes_test etc.) then add views defined in `ckeditor.urls` manually to your urls.py.
 


### PR DESCRIPTION
Just fix documentation (include without url not working on Django 1.11).

Problem: http://stackoverflow.com/questions/38786461/django-error-your-url-pattern-is-invalid-ensure-that-urlpatterns-is-a-list-of
