### PR TITLE
fix admin_base.css not found in package installed 

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,4 +6,5 @@ recursive-include ckeditor/static *
 recursive-include ckeditor/static *.asp *.php
 recursive-exclude ckeditor/static/ckeditor/ckeditor/_samples *
 recursive-include ckeditor/templates *
+recursive-include ckeditor_uploader/static *
 recursive-include ckeditor_uploader/templates *


### PR DESCRIPTION
modify MANIFEST.in to include ckeditor_uploader/static files.

#383 