### PR TITLE
Fix RST errors, for pretty display on PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.5"
   - "3.6"
 install:
-  - pip install flake8
+  - pip install flake8 docutils pygments
 script:
   - flake8
+  - python setup.py check --restructuredtext --strict --metadata

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,20 +4,20 @@ AUTHORS
 
 Created By
 ----------
-#. `shaunsephton <http://github.com/shaunsephton>`_
+#. `shaunsephton <http://github.com/shaunsephton>`__
 
 
 Contributors
 ------------
-#. `riklaunim <https://github.com/riklaunim>`_
-#. `3point2 <https://github.com/3point2>`_
-#. `buchuki <http://github.com/buchuki>`_
-#. `chr15m <http://github.com/chr15m>`_
-#. `hedleyroos <https://github.com/hedleyroos>`_
-#. `jeffh <https://github.com/jeffh>`_
-#. `lihan <https://github.com/lihan>`_
-#. `loop0 <http://github.com/loop0>`_
-#. `mwcz <https://github.com/mwcz>`_
-#. `tomwys <https://github.com/tomwys>`_
-#. `snbuback <https://github.com/snbuback>`_
-#. And others `<https://github.com/django-ckeditor/django-ckeditor/graphs/contributors>`_
+#. `riklaunim <https://github.com/riklaunim>`__
+#. `3point2 <https://github.com/3point2>`__
+#. `buchuki <http://github.com/buchuki>`__
+#. `chr15m <http://github.com/chr15m>`__
+#. `hedleyroos <https://github.com/hedleyroos>`__
+#. `jeffh <https://github.com/jeffh>`__
+#. `lihan <https://github.com/lihan>`__
+#. `loop0 <http://github.com/loop0>`__
+#. `mwcz <https://github.com/mwcz>`__
+#. `tomwys <https://github.com/tomwys>`__
+#. `snbuback <https://github.com/snbuback>`__
+#. And others `<https://github.com/django-ckeditor/django-ckeditor/graphs/contributors>`__

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -192,18 +192,18 @@ File upload support have been moved to ckeditor_uploader. The urls are in ckedit
 -----
 #. Include CKEditor version 3.6.2.
 #. Initial work on Django aligned theme.
-#. Fix schema slash removal issue on media url generation. Thanks `mwcz <https://github.com/mwcz>`_
-#. Added compatibility for South. Thanks `3point2 <https://github.com/3point2>`_
-#. Prevented settings from leaking between widget instances. Thanks `3point2 <https://github.com/3point2>`_
-#. Fixed config_name conflict when verbose_name is used as first positional argument for a field. Thanks `3point2 <https://github.com/3point2>`_
-#. Refactored views to allow use of file walking with local paths. Thanks `3point2 <https://github.com/3point2>`_
-#. Added command to generate thumbnails. Thanks `3point2 <https://github.com/3point2>`_
+#. Fix schema slash removal issue on media url generation. Thanks `mwcz <https://github.com/mwcz>`__
+#. Added compatibility for South. Thanks `3point2 <https://github.com/3point2>`__
+#. Prevented settings from leaking between widget instances. Thanks `3point2 <https://github.com/3point2>`__
+#. Fixed config_name conflict when verbose_name is used as first positional argument for a field. Thanks `3point2 <https://github.com/3point2>`__
+#. Refactored views to allow use of file walking with local paths. Thanks `3point2 <https://github.com/3point2>`__
+#. Added command to generate thumbnails. Thanks `3point2 <https://github.com/3point2>`__
 #. Migrated from using media to static file management.
 
 0.0.9
 -----
 
-#. Added ability to configure CKeditor through a CKEDITOR_CONFIGS settings. Thanks `jeffh <https://github.com/jeffh>`_ for the input.
+#. Added ability to configure CKeditor through a CKEDITOR_CONFIGS settings. Thanks `jeffh <https://github.com/jeffh>`__ for the input.
 
 0.0.8
 -----
@@ -217,14 +217,14 @@ File upload support have been moved to ckeditor_uploader. The urls are in ckedit
 0.0.6
 -----
 #. Enforce correct configuration.
-#. Changed upload behavior to separate files into directories by upload date. Thanks `loop0 <http://github.com/loop0>`_ .
-#. Added ability to limit user access to uploaded content (see the CKEDITOR_RESTRICT_BY_USER setting). Thanks `chr15m <http://github.com/chr15m>`_ for the input.
+#. Changed upload behavior to separate files into directories by upload date. Thanks `loop0 <http://github.com/loop0>`__ .
+#. Added ability to limit user access to uploaded content (see the CKEDITOR_RESTRICT_BY_USER setting). Thanks `chr15m <http://github.com/chr15m>`__ for the input.
 #. Added initial set of much needed tests.
 #. General cleanup, light refactor.
 
 0.0.5
 -----
-#. csrf_exempt backwards compatability. Thanks `chr15m <http://github.com/chr15m>`_ .
+#. csrf_exempt backwards compatability. Thanks `chr15m <http://github.com/chr15m>`__ .
 
 0.0.4
 -----
@@ -232,7 +232,7 @@ File upload support have been moved to ckeditor_uploader. The urls are in ckedit
 
 0.0.3
 -----
-#. More robust PIL import. Thanks `buchuki <http://github.com/buchuki>`_ .
+#. More robust PIL import. Thanks `buchuki <http://github.com/buchuki>`__ .
 #. Better CKEDITOR_MEDIA_PREFIX setting error.
 
 0.0.2
@@ -241,5 +241,5 @@ File upload support have been moved to ckeditor_uploader. The urls are in ckedit
 
 0.0.1
 -----
-#. Added CKEDITOR_UPLOAD_PREFIX setting. Thanks `chr15m <http://github.com/chr15m>`_ for the input.
+#. Added CKEDITOR_UPLOAD_PREFIX setting. Thanks `chr15m <http://github.com/chr15m>`__ for the input.
 

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ This version also includes:
 
 #. support to django-storages (works with S3)
 #. updated ckeditor to version 4.6.2
-#. included all ckeditor language and plugin files to made everyone happy! ( `only the plugins maintained by the ckeditor develops team <https://github.com/ckeditor/ckeditor-dev/tree/4.6.2/plugins>`_ )
+#. included all ckeditor language and plugin files to made everyone happy! ( `only the plugins maintained by the ckeditor develops team <https://github.com/ckeditor/ckeditor-dev/tree/4.6.2/plugins>`__ )
 
 .. contents:: Contents
    :depth: 5
@@ -34,7 +34,7 @@ Required
 
     CKEDITOR_JQUERY_URL = 'https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js'
 
-#. Run the ``collectstatic`` management command: ``$ ./manage.py collectstatic``. This will copy static CKEditor required media resources into the directory given by the ``STATIC_ROOT`` setting. See `Django's documentation on managing static files <https://docs.djangoproject.com/en/dev/howto/static-files>`_ for more info.
+#. Run the ``collectstatic`` management command: ``$ ./manage.py collectstatic``. This will copy static CKEditor required media resources into the directory given by the ``STATIC_ROOT`` setting. See `Django's documentation on managing static files <https://docs.djangoproject.com/en/dev/howto/static-files>`__ for more info.
 
 
 Required for using widget with file upload
@@ -107,7 +107,7 @@ Required for using widget with file upload
 Optional - customizing CKEditor editor
 --------------------------------------
 
-#. Add a CKEDITOR_CONFIGS setting to the project's ``settings.py`` file. This specifies sets of CKEditor settings that are passed to CKEditor (see CKEditor's `Setting Configurations <http://docs.ckeditor.com/#!/guide/dev_configuration>`_), i.e.::
+#. Add a CKEDITOR_CONFIGS setting to the project's ``settings.py`` file. This specifies sets of CKEditor settings that are passed to CKEditor (see CKEditor's `Setting Configurations <http://docs.ckeditor.com/#!/guide/dev_configuration>`__), i.e.::
 
        CKEDITOR_CONFIGS = {
            'awesome_ckeditor': {
@@ -223,7 +223,7 @@ Included is a management command to create thumbnails for images already contain
 
     $ ./manage.py generateckeditorthumbnails
 
-**NOTE**: If you're using custom views remember to include ckeditor.js in your form's media either through ``{{ form.media }}`` or through a ``<script>`` tag. Admin will do this for you automatically. See `Django's Form Media docs <http://docs.djangoproject.com/en/dev/topics/forms/media/>`_ for more info.
+**NOTE**: If you're using custom views remember to include ckeditor.js in your form's media either through ``{{ form.media }}`` or through a ``<script>`` tag. Admin will do this for you automatically. See `Django's Form Media docs <http://docs.djangoproject.com/en/dev/topics/forms/media/>`__ for more info.
 
 Using S3
 ~~~~~~~~
@@ -296,7 +296,7 @@ You can run the test with ``python manage.py test ckeditor_demo`` (for repo chec
 Running code quality tests
 --------------------------
 
-Create a new virtualenv, install `tox <https://pypi.python.org/pypi/tox>`_ and run ``tox -e py27-lint`` to `Flake8 (pep8 and other quality checks) <https://pypi.python.org/pypi/flake8>`_ tests or ``tox -e py27-isort`` to `isort (import order check) <https://pypi.python.org/pypi/isort>`_ tests
+Create a new virtualenv, install `tox <https://pypi.python.org/pypi/tox>`__ and run ``tox -e py27-lint`` to `Flake8 (pep8 and other quality checks) <https://pypi.python.org/pypi/flake8>`__ tests or ``tox -e py27-isort`` to `isort (import order check) <https://pypi.python.org/pypi/isort>`__ tests
 
 
 Troubleshooting

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,11 @@ if sys.argv[-1] == 'tag':
     os.system("git push --tags")
     sys.exit()
 
-long_description = open('README.rst', 'r').read() + open('AUTHORS.rst', 'r').read() + open('CHANGELOG.rst', 'r').read()
+long_description = "\n".join([
+    open('README.rst', 'r').read(),
+    open('AUTHORS.rst', 'r').read(),
+    open('CHANGELOG.rst', 'r').read(),
+])
 
 
 def get_source_files():


### PR DESCRIPTION
Currently, the RST is not formatted correctly on PyPI's website:

https://pypi.python.org/pypi/django-ckeditor/5.2.2

This pull request fixes the RST to make it work on the PyPI website. It fixed the errors that this command printed:

```
python setup.py check --restructuredtext --strict --metadata
```