### PR TITLE
Remove the jQuery requirement from ckeditor-init.js

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,12 @@ Next version
    Pillow image backend.
 #. Actually include static assets for ``ckeditor_uploader`` in the
    pip-installable package.
+#. Removed ``CKEDITOR_JQUERY_URL`` and the jQuery dependency. The
+   CKEditor activation now uses plain JavaScript. Dependencies are
+   `JSON.parse <http://caniuse.com/#search=json.parse>`__ and
+   `document.querySelectorAll <http://caniuse.com/#search=querySelectorAll>`__
+   which are supported in practically all used browsers these days.
+
 
 5.2.2
 -----

--- a/README.rst
+++ b/README.rst
@@ -30,10 +30,6 @@ Required
 
 #. Add ``ckeditor`` to your ``INSTALLED_APPS`` setting.
 
-#. **django-ckeditor uses jQuery in ckeditor-init.js file. You must set ``CKEDITOR_JQUERY_URL`` to a jQuery URL that will be used to load the library**. If you have jQuery loaded from a different source just don't set [CKEDITOR_JQUERY_URL] and django-ckeditor will not try to load its own jQuery. If you find that CKEditor widgets don't appear in your Django admin site, then check that this variable is set correctly. Example::
-
-    CKEDITOR_JQUERY_URL = 'https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js'
-
 #. Run the ``collectstatic`` management command: ``$ ./manage.py collectstatic``. This will copy static CKEditor required media resources into the directory given by the ``STATIC_ROOT`` setting. See `Django's documentation on managing static files <https://docs.djangoproject.com/en/dev/howto/static-files>`__ for more info.
 
 
@@ -78,13 +74,6 @@ Required for using widget with file upload
 #. Set ``CKEDITOR_IMAGE_BACKEND`` to one of the supported backends to enable thumbnails in ckeditor gallery. By default no thumbnails are created and full size images are used as preview. Supported backends:
 
    - ``pillow``: Uses Pillow
-
-#. django-ckeditor uses Django admin's jQuery by default. You may override this
-   by specifying a different jQuery as ``CKEDITOR_JQUERY_URL``. If you find
-   that CKEditor widgets don't appear in your Django admin site then check that
-   this variable is set correctly. Example::
-
-       CKEDITOR_JQUERY_URL = 'https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js'
 
 #. CKEditor needs to know where its assets are located because it loads them
    lazily only when needed. The location is determined by looking at a script

--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -58,9 +58,6 @@ class CKEditorWidget(forms.Textarea):
     """
     class Media:
         js = ()
-        jquery_url = getattr(settings, 'CKEDITOR_JQUERY_URL', None)
-        if jquery_url:
-            js += (jquery_url, )
         try:
             js += (
                 JS('ckeditor/ckeditor-init.js', {

--- a/ckeditor_demo/demo_application/templates/form.html
+++ b/ckeditor_demo/demo_application/templates/form.html
@@ -3,13 +3,11 @@
 <html>
     <head>
         <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
-        <script type="text/javascript" src="{% static "ckeditor/ckeditor-init.js" %}"></script>
-        <script type="text/javascript" src="{% static "ckeditor/ckeditor/ckeditor.js" %}"></script>
     </head>
     <body>
         <form method="post" action="./">
             {% csrf_token %}
+            {{ form.media }}
             {{ form.as_p }}
             <p><input type="submit" value="post"></p>
         </form>

--- a/ckeditor_demo/settings.py
+++ b/ckeditor_demo/settings.py
@@ -124,7 +124,6 @@ MEDIA_ROOT = os.path.join(tempfile.gettempdir(), 'ck_media')
 
 CKEDITOR_UPLOAD_PATH = "uploads/"
 CKEDITOR_IMAGE_BACKEND = "pillow"
-CKEDITOR_JQUERY_URL = '//ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js'
 
 # New
 IMAGE_QUALITY = 40


### PR DESCRIPTION
This isn't very useful for the admin panel as Django always loads a jQuery instance there; but it's very useful when used on a website programmed without jQuery, or without jQuery readily available (such as when using webpack or something similar)

I did test the admin integration (both inline and no inline), and also external plugin support which I've documented in https://github.com/django-ckeditor/django-ckeditor/commit/4fba4699c45921e0fa07f68fed639a3e28923568

I did not test grappelli, but don't know why that wouldn't work as well.