### PR TITLE
Fix setting config language

### DIFF
--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -138,5 +138,4 @@ class CKEditorWidget(forms.Textarea):
         return attrs
 
     def _set_config(self):
-        if not self.config.get('language'):
-            self.config['language'] = get_language()
+        self.config['language'] = get_language()


### PR DESCRIPTION
This bug consists in following:

1. Django widgets are initialized on startup. It`s mean that for one RichTextField field will be created one CKEditorWidget widget on the startup. Every request to show this field on a form will use the same widget.
2. Method `CKEditorWidget.render()` is called every time the form displays. Another method 
`_set_config` is called inside: https://github.com/django-ckeditor/django-ckeditor/blob/master/ckeditor/widgets.py#L118

3. This method `_set_config` set the language in such way: if the language does not exist in attribute `config`, it takes language from `django.utils.translation.get_language`. BUT, if there is anything in `config['language']` - it does nothing (actually it leave the PREVIOUS language - it is the bug).

4. So, it turns out that if the form is displayed on the second time it will use the language from the previous time. For example, if the first request (after startup) is sent from English user - CKEditor will display language correctly, but if the next request will be sent from any other country, for example, France - it will display with English, not French, anyway.