### PR TITLE
A TypeError Exception is raised when CKEDITOR_RESTRICT_BY_USER is True

### DIFF
--- a/ckeditor_uploader/views.py
+++ b/ckeditor_uploader/views.py
@@ -26,7 +26,7 @@ def get_upload_filename(upload_name, user):
     if RESTRICT_BY_USER:
         try:
             user_prop = getattr(user, RESTRICT_BY_USER)
-        except AttributeError:
+        except (AttributeError, TypeError):
             user_prop = getattr(user, 'get_username')
 
         if callable(user_prop):


### PR DESCRIPTION
A `TypeError` exception is raised during image uploading when `CKEDITOR_RESTRICT_BY_USER` is `True` because a bool value can not be passed to `getattr` function.

`  File "/home/pchinea/env/local/lib/python2.7/site-packages/ckeditor_uploader/views.py", line 28, in get_upload_filename
    user_prop = getattr(user, RESTRICT_BY_USER)
TypeError: getattr(): attribute name must be string`