### PR TITLE
Convert Chinese language identifiers

### DIFF
--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -138,4 +138,9 @@ class CKEditorWidget(forms.Textarea):
         return attrs
 
     def _set_config(self):
-        self.config['language'] = get_language()
+        lang = get_language()
+        if lang == 'zh-hans':
+            lang = 'zh-cn'
+        elif lang == 'zh-hant':
+            lang = 'zh'
+        self.config['language'] = lang


### PR DESCRIPTION
In Django 1.11, language identifiers for Simplified/Traditional Chinese are 'zh-hans' and 'zh-hant'.
In CKEditor, the keys to the two translations are 'zh-cn' and 'zh', respectively. If `django.utils.translation.get_language` returns `zh-hans`, CKEditor will render UI with translation of `zh` which is equivalent to `zh-hant` rather than `zh-hans`.

This patch converts the identifier between two conventions.