### PR TITLE
Allow for custom storage backends for uploader

### DIFF
--- a/ckeditor_uploader/image/pillow_backend.py
+++ b/ckeditor_uploader/image/pillow_backend.py
@@ -4,8 +4,8 @@ import os
 from io import BytesIO
 
 from django.conf import settings
-from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import InMemoryUploadedFile
+from ckeditor_uploader.utils import storage
 
 from PIL import Image, ImageOps
 
@@ -26,7 +26,7 @@ def create_thumbnail(file_path):
     thumbnail_filename = utils.get_thumb_filename(file_path)
     thumbnail_format = utils.get_image_format(os.path.splitext(file_path)[1])
 
-    image = default_storage.open(file_path)
+    image = storage.open(file_path)
     image = Image.open(image)
     file_format = image.format
 
@@ -50,11 +50,11 @@ def create_thumbnail(file_path):
         None)
     thumbnail.seek(0)
 
-    return default_storage.save(thumbnail_filename, thumbnail)
+    return storage.save(thumbnail_filename, thumbnail)
 
 
 def should_create_thumbnail(file_path):
-    image = default_storage.open(file_path)
+    image = storage.open(file_path)
     try:
         Image.open(image)
     except IOError:

--- a/ckeditor_uploader/utils.py
+++ b/ckeditor_uploader/utils.py
@@ -7,11 +7,12 @@ import re
 import string
 
 from django.conf import settings
-from django.core.files.storage import default_storage
 from django.template.defaultfilters import slugify
 from django.utils.encoding import force_text
+from django.utils.module_loading import import_string
 
 # Non-image file icons, matched from top to bottom
+
 fileicons_path = '{0}/file-icons/'.format(getattr(settings, 'CKEDITOR_FILEICONS_PATH', '/static/ckeditor'))
 # This allows adding or overriding the default icons used by Gallerific by getting an additional two-tuple list from
 # the project settings.  If it does not exist, it is ignored.  If the same file extension exists twice, the settings
@@ -30,6 +31,13 @@ CKEDITOR_FILEICONS = override_icons + ckeditor_icons
 
 class NotAnImageException(Exception):
     pass
+
+
+# Allow for a custom storage backend defined in settings.
+def get_storage_class():
+    return import_string(getattr(settings, 'CKEDITOR_STORAGE_BACKEND', 'django.core.files.storage.DefaultStorage'))()
+
+storage = get_storage_class()
 
 
 def slugify_filename(filename):
@@ -74,7 +82,7 @@ def get_media_url(path):
     """
     Determine system file's media URL.
     """
-    return default_storage.url(path)
+    return storage.url(path)
 
 
 def is_valid_image_extension(file_path):

--- a/ckeditor_uploader/utils.py
+++ b/ckeditor_uploader/utils.py
@@ -37,6 +37,7 @@ class NotAnImageException(Exception):
 def get_storage_class():
     return import_string(getattr(settings, 'CKEDITOR_STORAGE_BACKEND', 'django.core.files.storage.DefaultStorage'))()
 
+
 storage = get_storage_class()
 
 

--- a/ckeditor_uploader/views.py
+++ b/ckeditor_uploader/views.py
@@ -4,7 +4,6 @@ import os
 from datetime import datetime
 
 from django.conf import settings
-from django.core.files.storage import default_storage
 from django.http import HttpResponse, JsonResponse
 from django.shortcuts import render
 from django.utils.html import escape
@@ -15,6 +14,7 @@ from django.views.decorators.csrf import csrf_exempt
 from PIL import Image
 
 from ckeditor_uploader import image_processing, utils
+from ckeditor_uploader.utils import storage
 from ckeditor_uploader.forms import SearchForm
 
 
@@ -61,7 +61,7 @@ def get_upload_filename(upload_name, user):
         generator = import_string(settings.CKEDITOR_FILENAME_GENERATOR)
         upload_name = generator(upload_name)
 
-    return default_storage.get_available_name(
+    return storage.get_available_name(
         os.path.join(upload_path, upload_name)
     )
 
@@ -118,18 +118,18 @@ class ImageUploadView(generic.View):
 
             img = Image.open(uploaded_file)
             img = img.resize(img.size, Image.ANTIALIAS)
-            saved_path = default_storage.save("{}.jpg".format(img_name), uploaded_file)
+            saved_path = storage.save("{}.jpg".format(img_name), uploaded_file)
             img.save("{}.jpg".format(img_name), quality=IMAGE_QUALITY, optimize=True)
 
         elif(str(img_format).lower() == "jpg" or str(img_format).lower() == "jpeg"):
 
             img = Image.open(uploaded_file)
             img = img.resize(img.size, Image.ANTIALIAS)
-            saved_path = default_storage.save(filename, uploaded_file)
+            saved_path = storage.save(filename, uploaded_file)
             img.save(saved_path, quality=IMAGE_QUALITY, optimize=True)
 
         else:
-            saved_path = default_storage.save(filename, uploaded_file)
+            saved_path = storage.save(filename, uploaded_file)
 
         return saved_path
 
@@ -162,7 +162,7 @@ def get_image_files(user=None, path=''):
     browse_path = os.path.join(settings.CKEDITOR_UPLOAD_PATH, user_path, path)
 
     try:
-        storage_list = default_storage.listdir(browse_path)
+        storage_list = storage.listdir(browse_path)
     except NotImplementedError:
         return
     except OSError:


### PR DESCRIPTION
This is useful for allowing uploaded files to be in a different location than default storage. For instance, when used with django-storages, this allows for the default storage to be private (with querystring auth for S3) so that all files don't need to be public. But we can create a custom storage class for CKEditor uploads that is public so that anything uploaded will be accessible (useful if using ckeditor to send emails with).

I have tested with django-storages using s3 and local storage.