### PR TITLE
Fix to make ckeditor work with google material design lite

### DIFF
--- a/ckeditor/static/ckeditor/ckeditor-init.js
+++ b/ckeditor/static/ckeditor/ckeditor-init.js
@@ -26,10 +26,8 @@
     initialiseCKEditorInInlinedForms();
   }
 
-  if (document.readyState != 'loading') {
+  window.onload = function() {
     runInitialisers();
-  } else {
-    document.addEventListener('DOMContentLoaded', runInitialisers);
   }
 
   function initialiseCKEditor() {


### PR DESCRIPTION
Temporary fix to make ckeditor work with Google MDL framework.
Issue: https://github.com/django-ckeditor/django-ckeditor/issues/429 