### PR TITLE
ckeditor uploader widget urlresolver import with django 2.0

### DIFF
--- a/ckeditor_uploader/widgets.py
+++ b/ckeditor_uploader/widgets.py
@@ -1,4 +1,9 @@
-from django.core.urlresolvers import reverse
+from django import get_version
+
+if get_version()[0] == '2':
+    from django.urls import reverse
+else:
+    from django.core.urlresolvers import reverse
 
 from ckeditor import widgets
 


### PR DESCRIPTION
From Django 2.0 changes:

* The `django.core.urlresolvers` module is removed in favor of its new location, `django.urls`.