### PR TITLE
Added casting _get_user_path result to a string

### DIFF
--- a/ckeditor_uploader/views.py
+++ b/ckeditor_uploader/views.py
@@ -34,7 +34,7 @@ def _get_user_path(user):
         else:
             user_path = user_prop
 
-    return user_path
+    return str(user_path)
 
 
 def get_upload_filename(upload_name, user):


### PR DESCRIPTION
If you use non-string properties of user object get_upload_filename will be failed. e.g. CKEDITOR_RESTRICT_BY_USER='id'