### PR TITLE
Documentation for #377 'Automatically set CKEDITOR_BASEPATH'

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -34,19 +34,23 @@ Required
 #. Run the ``collectstatic`` management command: ``$ ./manage.py collectstatic``. This will copy static CKEditor required media resources into the directory given by the ``STATIC_ROOT`` setting. See `Django's documentation on managing static files <https://docs.djangoproject.com/en/dev/howto/static-files>`__ for more info.
 
 #. CKEditor needs to know where its assets are located because it loads them
-   lazily only when needed. The location is determined by looking at a script
-   tag which includes a URL ending in ``ckeditor.js``. This does not work all
+   lazily only when needed. The location is determined in the ``ckeditor-init.js``
+   script. and defaults to ``static/ckeditor/ckeditor/``. This does not work all 
    the time, for example when using ``ManifestStaticFilesStorage``, any asset
-   packaging pipeline or whatnot. django-ckeditor is quite good at
-   automatically detecting the correct place even then, but sometimes you have
-   to hardcode ``CKEDITOR_BASEPATH`` somewhere. It is recommended to override
-   the ``admin/base_site.html`` template with your own if you really need to do
+   packaging pipeline or whatnot. django-ckeditor is quite good at automatically 
+   detecting the correct place even then, but sometimes you have to hardcode 
+   ``CKEDITOR_BASEPATH`` somewhere. This can be hardcoded in settings, i.e.::
+
+        CKEDITOR_BASEPATH = "/my_static/ckeditor/ckeditor"
+
+   It is possible to override
+   the ``admin/change_form.html`` template with your own if you really need to do
    this, i.e.::
 
-        {% extends "admin/base_site.html" %}
+        {% extends "admin/change_form.html" %}
 
         {% block extrahead %}
-        <script>window.CKEDITOR_BASEPATH = '/static/ckeditor/ckeditor/';</script>
+        <script>window.CKEDITOR_BASEPATH = '/my_static/ckeditor/ckeditor/';</script>
         {{ block.super }}
         {% endblock %}
 


### PR DESCRIPTION
Refs #377 #382 

widgets.py now looks for CKEDITOR_BASEPATH value in settings, and defaults to `static('ckeditor/ckeditor/')`

References changes made to widgets.py on line 68. (https://github.com/django-ckeditor/django-ckeditor/blob/master/ckeditor/widgets.py#L68)

Also changes admin/base_site.html to admin/change_form.html because it
is more specific and is easier to extend.
