### PR TITLE
Add template rendering example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -225,7 +225,8 @@ or you can load the media manually as it is done in the demo app::
     {% load static %}
     <script type="text/javascript" src="{% static "ckeditor/ckeditor-init.js" %}"></script>
     <script type="text/javascript" src="{% static "ckeditor/ckeditor/ckeditor.js" %}"></script>
-
+    
+When you need to render ``RichtextField``'s html output in your templates, just use ``{% autoescape on %}{{ content }}{% endautoescape %}``
 
 
 Management Commands

--- a/README.rst
+++ b/README.rst
@@ -226,7 +226,7 @@ or you can load the media manually as it is done in the demo app::
     <script type="text/javascript" src="{% static "ckeditor/ckeditor-init.js" %}"></script>
     <script type="text/javascript" src="{% static "ckeditor/ckeditor/ckeditor.js" %}"></script>
     
-When you need to render ``RichtextField``'s html output in your templates, just use ``{% autoescape on %}{{ content }}{% endautoescape %}``
+When you need to render ``RichTextField``'s html output in your templates safely, just use ``{{ content|safe }}``,  `Django's safe filter <https://docs.djangoproject.com/en/2.0/ref/templates/builtins/#std:templatefilter-safe>`_
 
 
 Management Commands

--- a/README.rst
+++ b/README.rst
@@ -226,7 +226,7 @@ or you can load the media manually as it is done in the demo app::
     <script type="text/javascript" src="{% static "ckeditor/ckeditor-init.js" %}"></script>
     <script type="text/javascript" src="{% static "ckeditor/ckeditor/ckeditor.js" %}"></script>
     
-When you need to render ``RichTextField``'s html output in your templates safely, just use ``{{ content|safe }}``,  `Django's safe filter <https://docs.djangoproject.com/en/2.0/ref/templates/builtins/#std:templatefilter-safe>`_
+When you need to render ``RichTextField``'s HTML output in your templates safely, just use ``{{ content|safe }}``,  `Django's safe filter <https://docs.djangoproject.com/en/2.0/ref/templates/builtins/#std:templatefilter-safe>`_
 
 
 Management Commands


### PR DESCRIPTION
I've just added a note on how to render html content inside templates, for newcomers reading README file