### PR TITLE
Modify widget sample in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -203,6 +203,7 @@ Alernatively you can use the included ``CKEditorWidget`` as the widget for a for
         content = forms.CharField(widget=CKEditorWidget())
         class Meta:
             model = Post
+            fields = '__all__'
 
     class PostAdmin(admin.ModelAdmin):
         form = PostAdminForm


### PR DESCRIPTION
For compatibility with Django 2.1.
I got an exception without  `fields = '__all__' `.

`django.core.exceptions.ImproperlyConfigured: Creating a ModelForm without either the 'fields' attribute or the 'exclude' attribute is prohibited; form PostAdminForm needs updating.`