### PR TITLE
Fix regression - lib works again for Django 1.8--1.10. Cleanup tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,33 @@
+dist: trusty
+addons:
+  chrome: stable
 language: python
 sudo: false
 python:
   - "3.5"
   - "3.6"
+
+env:
+  - DJANGO=1.11
+  - DJANGO=2.1
+
+matrix:
+  include:
+    - python: "2.7"
+      env: DJANGO=1.11
+    - python: "2.7"
+      env: DJANGO=1.8
+
 install:
-  - pip install flake8 docutils pygments
+  - travis_retry pip install -U tox-travis
+  - wget -N http://chromedriver.storage.googleapis.com/70.0.3538.16/chromedriver_linux64.zip -P ~/
+  - unzip ~/chromedriver_linux64.zip -d ~/
+  - rm ~/chromedriver_linux64.zip
+  - sudo mv -f ~/chromedriver /usr/local/share/
+  - sudo chmod +x /usr/local/share/chromedriver
+  - sudo ln -s /usr/local/share/chromedriver /usr/local/bin/chromedriver
+  - export PATH=$PATH:/usr/local/bin/
 script:
-  - flake8
-  - python setup.py check --restructuredtext --strict --metadata
+  - whereis google-chrome-stable
+  - whereis chromedriver
+  - tox

--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -9,9 +9,23 @@ from django.utils.functional import Promise
 from django.utils.html import conditional_escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language
-from django.forms.widgets import get_default_renderer
 
 from js_asset import JS, static
+
+try:
+    # Django >=1.11
+    from django.forms.widgets import get_default_renderer
+except ImportError:
+    # Django <1.11
+    from django.template.loader import render_to_string
+
+    def get_default_renderer():
+        class DummyDjangoRenderer(object):
+            @staticmethod
+            def render(*args, **kwargs):
+                return render_to_string(*args, **kwargs)
+
+        return DummyDjangoRenderer
 
 try:
     # Django >=1.7
@@ -56,6 +70,7 @@ class CKEditorWidget(forms.Textarea):
     Widget providing CKEditor for Rich Text Editing.
     Supports direct image uploads and embed.
     """
+
     class Media:
         js = (
             JS('ckeditor/ckeditor-init.js', {

--- a/ckeditor_demo/demo_application/tests.py
+++ b/ckeditor_demo/demo_application/tests.py
@@ -23,7 +23,10 @@ class TestAdminPanelWidget(StaticLiveServerTestCase):
     @classmethod
     def setUpClass(cls):
         if SELENIUM_BROWSER == CHROMIUM:
-            cls.selenium = webdriver.Chrome(executable_path='chromedriver')
+            options = webdriver.ChromeOptions()
+            options.add_argument('--headless')
+            options.add_argument('--disable-gpu')
+            cls.selenium = webdriver.Chrome(chrome_options=options)
         elif SELENIUM_BROWSER == FIREFOX:
             cls.selenium = webdriver.Firefox()
         super(TestAdminPanelWidget, cls).setUpClass()

--- a/ckeditor_uploader/image/pillow_backend.py
+++ b/ckeditor_uploader/image/pillow_backend.py
@@ -5,11 +5,11 @@ from io import BytesIO
 
 from django.conf import settings
 from django.core.files.uploadedfile import InMemoryUploadedFile
-from ckeditor_uploader.utils import storage
 
 from PIL import Image, ImageOps
 
 from ckeditor_uploader import utils
+from ckeditor_uploader.utils import storage
 
 THUMBNAIL_SIZE = getattr(settings, "THUMBNAIL_SIZE", (75, 75))
 

--- a/ckeditor_uploader/views.py
+++ b/ckeditor_uploader/views.py
@@ -14,8 +14,8 @@ from django.views.decorators.csrf import csrf_exempt
 from PIL import Image
 
 from ckeditor_uploader import image_processing, utils
-from ckeditor_uploader.utils import storage
 from ckeditor_uploader.forms import SearchForm
+from ckeditor_uploader.utils import storage
 
 
 def _get_user_path(user):
@@ -38,7 +38,6 @@ def _get_user_path(user):
 
 
 def get_upload_filename(upload_name, user):
-
     user_path = _get_user_path(user)
 
     # Generate date based path to put uploaded file.
@@ -92,7 +91,7 @@ class ImageUploadView(generic.View):
                     </script>""".format(ck_func_num))
 
         saved_path = self._save_file(request, uploaded_file)
-        if(str(saved_path).split('.')[1].lower() != 'gif'):
+        if (str(saved_path).split('.')[1].lower() != 'gif'):
             self._create_thumbnail_if_needed(backend, saved_path)
         url = utils.get_media_url(saved_path)
 
@@ -114,14 +113,14 @@ class ImageUploadView(generic.View):
         img_name, img_format = os.path.splitext(filename)
         IMAGE_QUALITY = getattr(settings, "IMAGE_QUALITY", 60)
 
-        if(str(img_format).lower() == "png"):
+        if (str(img_format).lower() == "png"):
 
             img = Image.open(uploaded_file)
             img = img.resize(img.size, Image.ANTIALIAS)
             saved_path = storage.save("{}.jpg".format(img_name), uploaded_file)
             img.save("{}.jpg".format(img_name), quality=IMAGE_QUALITY, optimize=True)
 
-        elif(str(img_format).lower() == "jpg" or str(img_format).lower() == "jpeg"):
+        elif (str(img_format).lower() == "jpg" or str(img_format).lower() == "jpeg"):
 
             img = Image.open(uploaded_file)
             img = img.resize(img.size, Image.ANTIALIAS)
@@ -223,7 +222,7 @@ def browse(request):
         if form.is_valid():
             query = form.cleaned_data.get('q', '').lower()
             files = list(filter(lambda d: query in d[
-                         'visible_filename'].lower(), files))
+                'visible_filename'].lower(), files))
     else:
         form = SearchForm()
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,8 +3,14 @@ skip_missing_interpreters=True
 envlist=
     py27-coverage-init
     {py27,py36}-django{18,19,110,111}
-    py36-django20
+    py36-django{20,21}
     py27-{lint,isort,coverage-report}
+
+[travis:env]
+DJANGO =
+    1.8: django18
+    1.11: django111
+    2.1: django21
 
 [testenv]
 usedevelop=True
@@ -25,6 +31,7 @@ deps=
     django110: Django>=1.10,<1.11
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
 
 [testenv:py27-coverage-init]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 skip_missing_interpreters=True
 envlist=
     py27-coverage-init
-    {py27,py34}-django{18,19,110,111}
-    py34-django20
+    {py27,py36}-django{18,19,110,111}
+    py36-django20
     py27-{lint,isort,coverage-report}
 
 [testenv]


### PR DESCRIPTION
I needed this lib for legacy project based on Django 1.9 and it didn't work. Here's the fix :slightly_smiling_face: 