### PR TITLE
Fix initialization on old versions of Internet Explorer

### DIFF
--- a/ckeditor/static/ckeditor/ckeditor-init.js
+++ b/ckeditor/static/ckeditor/ckeditor-init.js
@@ -31,7 +31,8 @@
     initialiseCKEditorInInlinedForms();
   }
 
-  if (document.readyState != 'loading') {
+  if (document.readyState != 'loading' && document.body) {
+    document.addEventListener('DOMContentLoaded', initialiseCKEditor);
     runInitialisers();
   } else {
     document.addEventListener('DOMContentLoaded', runInitialisers);


### PR DESCRIPTION
Using the virtual machines that are provided by Microsoft for testing Internet Explorer (I've tested IE 9 and IE 10 on Windows 7), rich text fields never seem to be initialized properly.

From what I can tell, IE will set 'document.readyState' to 'interactive' even while the document is still loading.  As a result, the initialiseCKEditor function in ckeditor-init.js is invoked immediately.

 * If the textarea itself has not yet been loaded at the time ckeditor-init.js is executed, initialiseCKEditor will never see it.

 * If the textarea has been loaded, but 'ckeditor.js' hasn't yet been loaded, initialiseCKEditor will fail because CKEDITOR is undefined.  This is fixed by commit 9eb93f97d35ae589e9ca9b2628e3028a4cde1786.

With this change, combined with commit 9eb93f97d35ae589e9ca9b2628e3028a4cde1786, the script ought to work:
- regardless of whether ckeditor-init.js is placed from the head or body
- regardless of whether it's placed before or after ckeditor.js
- regardless of whether it's placed before or after the textarea element(s)
