### PR TITLE
fix template tag in uploader to work with Django 3

### DIFF
--- a/ckeditor_uploader/templates/ckeditor/browse.html
+++ b/ckeditor_uploader/templates/ckeditor/browse.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <html>
     <head>
         <meta http-equiv="Content-type" content="text/html; charset=utf-8">


### PR DESCRIPTION
I was getting an error in ckeditor uploader after clicking browse server. It seems that it is because Django 3 [doesn't accepts the template tag `staticfiles` anymore](https://stackoverflow.com/a/59381302/7373121), so it should be replace with ´static`.
I've tested this modification with Django 2.2 as well and it didn't break anything, so I think it ok.

![image](https://user-images.githubusercontent.com/3889382/71551292-abbe6f80-29c2-11ea-836a-413efda7b538.png)
