### PR TITLE
Fix add new inline on grappelli

### DIFF
--- a/ckeditor/static/ckeditor/ckeditor-init.js
+++ b/ckeditor/static/ckeditor/ckeditor-init.js
@@ -57,7 +57,8 @@
     document.body.addEventListener('click', function(e) {
       if (e.target && (
         e.target.matches('.add-row a') ||
-        e.target.matches('.grp-add-handler')
+        e.target.matches('.grp-add-handler') ||
+        e.target.parentElement.matches('.grp-add-handler')
       )) {
         initialiseCKEditor();
       }


### PR DESCRIPTION
Capture when the user clicks on the span for adding new inline.
![Slice 1](https://user-images.githubusercontent.com/8862343/79210664-793b6400-7e45-11ea-8cd1-4f16eb894aa4.png)

