### PR TITLE
Support django-nested-admin, django-polymorphic, and django-grappelli inlines

### DIFF
--- a/ckeditor/static/ckeditor/ckeditor-init.js
+++ b/ckeditor/static/ckeditor/ckeditor-init.js
@@ -1,24 +1,8 @@
-/* global CKEDITOR */
+/* global CKEDITOR, django */
 ;(function() {
   var el = document.getElementById('ckeditor-init-script');
   if (el && !window.CKEDITOR_BASEPATH) {
     window.CKEDITOR_BASEPATH = el.getAttribute('data-ckeditor-basepath');
-  }
-
-  // Polyfill from https://developer.mozilla.org/en/docs/Web/API/Element/matches
-  if (!Element.prototype.matches) {
-    Element.prototype.matches =
-        Element.prototype.matchesSelector ||
-        Element.prototype.mozMatchesSelector ||
-        Element.prototype.msMatchesSelector ||
-        Element.prototype.oMatchesSelector ||
-        Element.prototype.webkitMatchesSelector ||
-        function(s) {
-            var matches = (this.document || this.ownerDocument).querySelectorAll(s),
-                i = matches.length;
-            while (--i >= 0 && matches.item(i) !== this) {}
-            return i > -1;
-        };
   }
 
   function runInitialisers() {
@@ -54,14 +38,9 @@
   }
 
   function initialiseCKEditorInInlinedForms() {
-    document.body.addEventListener('click', function(e) {
-      if (e.target && (
-        e.target.matches('.add-row a') ||
-        e.target.matches('.grp-add-handler')
-      )) {
-        initialiseCKEditor();
-      }
-    });
+    if (typeof django === 'object' && django.jQuery) {
+      django.jQuery(document).on('formset:added', initialiseCKEditor);
+    }
   }
 
 }());


### PR DESCRIPTION
Since django 1.9, adding an inline in the admin triggers the jQuery event "formset:added" ([docs](https://docs.djangoproject.com/en/3.1/ref/contrib/admin/javascript/)). Libraries that extend the django admin have adopted this convention, and likewise fire this event when adding an inline.

By calling the initialize function from an event listener for this event, we can ensure that django-ckeditor fields get replaced regardless of the mechanism (or the selector of the element) that adds formset inlines. This ensures compatibility with django-grappelli, django-polymorphic, and django-nested-admin. Merging this will fix theatlantic/django-nested-admin#175