### PR TITLE
replace `ugettext_lazy` with `gettext_lazy` to get rid deprecation warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 Unreleased
 ----------
 
+#. Replace ``ugettext_lazy()`` with ``gettext_lazy()``
+
+
 5.9.0
 -----
 #. Django 3.0 support

--- a/ckeditor_uploader/forms.py
+++ b/ckeditor_uploader/forms.py
@@ -1,7 +1,10 @@
 from __future__ import absolute_import
 
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+try:
+    from django.utils.translation import gettext_lazy as _
+except ImportError:
+    from django.utils.translation import ugettext_lazy as _
 
 
 class SearchForm(forms.Form):


### PR DESCRIPTION
this PR fixes #618 