### PR TITLE
Changing 'django.conf.urls.url()' to 'django.urls.re_path()' because of depreciation

### DIFF
--- a/ckeditor_demo/urls.py
+++ b/ckeditor_demo/urls.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from django.conf import settings
-from django.conf.urls import include, url
+from django.urls import re_path, include
 from django.conf.urls.static import static
 from django.contrib import admin
 
@@ -9,9 +9,9 @@ from .demo_application.views import ckeditor_form_view
 
 urlpatterns = (
     [
-        url(r"^$", ckeditor_form_view, name="ckeditor-form"),
-        url(r"^admin/", admin.site.urls),
-        url(r"^ckeditor/", include("ckeditor_uploader.urls")),
+        re_path(r"^$", ckeditor_form_view, name="ckeditor-form"),
+        re_path(r"^admin/", admin.site.urls),
+        re_path(r"^ckeditor/", include("ckeditor_uploader.urls")),
     ]
     + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
     + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/ckeditor_uploader/urls.py
+++ b/ckeditor_uploader/urls.py
@@ -1,14 +1,14 @@
 from __future__ import absolute_import
 
-from django.conf.urls import url
+from django.urls import re_path
 from django.contrib.admin.views.decorators import staff_member_required
 from django.views.decorators.cache import never_cache
 
 from . import views
 
 urlpatterns = [
-    url(r"^upload/", staff_member_required(views.upload), name="ckeditor_upload"),
-    url(
+    re_path(r"^upload/", staff_member_required(views.upload), name="ckeditor_upload"),
+    re_path(
         r"^browse/",
         never_cache(staff_member_required(views.browse)),
         name="ckeditor_browse",


### PR DESCRIPTION
This pull request is linked to issue #617 

Any doubt I will be available :)