### PR TITLE
Update CKEDITOR_IMAGE_BACKEND to fully qualified path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -177,12 +177,12 @@ Optional for file upload
    By default, no thumbnails are created and full-size images are used as preview.
    Supported backends:
 
-   - ``pillow``: Uses Pillow
+   - ``ckeditor_uploader.backends.PillowBackend``: Uses Pillow
 
-#. With the ``pillow`` backend, you can change the thumbnail size with the ``CKEDITOR_THUMBNAIL_SIZE`` setting (formerly ``THUMBNAIL_SIZE``).
+#. With the ``PillowBackend`` backend, you can change the thumbnail size with the ``CKEDITOR_THUMBNAIL_SIZE`` setting (formerly ``THUMBNAIL_SIZE``).
    Default value: (75, 75)
 
-#. With the ``pillow`` backend, you can convert and compress the uploaded images to jpeg, to save disk space.
+#. With the ``PillowBackend`` backend, you can convert and compress the uploaded images to jpeg, to save disk space.
    Set the ``CKEDITOR_FORCE_JPEG_COMPRESSION`` setting to ``True`` (default ``False``)
    You can change the ``CKEDITOR_IMAGE_QUALITY`` setting (formerly ``IMAGE_QUALITY``), which is passed to Pillow:
 

--- a/ckeditor_demo/demo_application/tests/test_custom_backend.py
+++ b/ckeditor_demo/demo_application/tests/test_custom_backend.py
@@ -1,0 +1,16 @@
+from django import test
+
+from ckeditor_uploader import backends
+
+
+class CustomBackend:
+    pass
+
+
+class TestSelectingCustomBackend(test.SimpleTestCase):
+    @test.override_settings(
+        CKEDITOR_IMAGE_BACKEND="ckeditor_demo.demo_application.tests.test_custom_backend.CustomBackend"
+    )
+    def test_setting_returns_custom_backend(self):
+        result = backends.get_backend()
+        self.assertEqual(result, CustomBackend)

--- a/ckeditor_demo/demo_application/tests/test_deprecation.py
+++ b/ckeditor_demo/demo_application/tests/test_deprecation.py
@@ -2,9 +2,10 @@ import os
 import warnings
 
 from django.contrib.auth.models import User
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, SimpleTestCase, TestCase
 from django.test.utils import override_settings
 
+from ckeditor_uploader import backends
 from ckeditor_uploader.views import get_upload_filename
 
 from .utils import get_absolute_name
@@ -73,3 +74,21 @@ class TestUploadFilenameGeneratorParameters(TestCase):
 
         self.assertIn(MOCK_FILENAME, generated_filename)
         self.assertNotIn(GENERATOR_PREFIX, generated_filename)
+
+
+class TestDeprecatedImageBackendValues(SimpleTestCase):
+    @override_settings(CKEDITOR_IMAGE_BACKEND="pillow")
+    def test_pillow_setting(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = backends.get_backend()
+            self.assertEqual(len(w), 1)
+            self.assertEqual(result, backends.PillowBackend)
+
+    @override_settings(CKEDITOR_IMAGE_BACKEND=None)
+    def test_none_setting(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            result = backends.get_backend()
+            self.assertEqual(len(w), 1)
+            self.assertEqual(result, backends.DummyBackend)

--- a/ckeditor_demo/demo_application/tests/test_dummy.py
+++ b/ckeditor_demo/demo_application/tests/test_dummy.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 from .utils import get_absolute_media_path, get_media_url, remove_upload_directory, sha1
 
 
-@override_settings(CKEDITOR_IMAGE_BACKEND=None)
+@override_settings(CKEDITOR_IMAGE_BACKEND='ckeditor_uploader.backends.DummyBackend')
 class DummyTestCase(TestCase):
     fixtures = ["test_admin.json"]
 

--- a/ckeditor_demo/demo_application/tests/tests_functional.py
+++ b/ckeditor_demo/demo_application/tests/tests_functional.py
@@ -118,7 +118,7 @@ class TestAdminPanelWidget(StaticLiveServerTestCase):
         assert size > 0
 
 
-@override_settings(CKEDITOR_IMAGE_BACKEND=None)
+@override_settings(CKEDITOR_IMAGE_BACKEND='ckeditor_uploader.backends.DummyBackend')
 class TestAdminPanelWidgetForDummyImageBackend(TestAdminPanelWidget):
     def _assert_image_uploaded(self):
         upload_directory = get_upload_directory()

--- a/ckeditor_demo/settings.py
+++ b/ckeditor_demo/settings.py
@@ -118,7 +118,7 @@ MEDIA_ROOT = os.path.join(tempfile.gettempdir(), "ck_media")
 from ckeditor.configs import DEFAULT_CONFIG  # noqa
 
 CKEDITOR_UPLOAD_PATH = "uploads/"
-CKEDITOR_IMAGE_BACKEND = "pillow"
+CKEDITOR_IMAGE_BACKEND = "ckeditor_uploader.backends.PillowBackend"
 CKEDITOR_THUMBNAIL_SIZE = (300, 300)
 CKEDITOR_IMAGE_QUALITY = 40
 CKEDITOR_BROWSE_SHOW_DIRS = True

--- a/ckeditor_uploader/views.py
+++ b/ckeditor_uploader/views.py
@@ -12,7 +12,7 @@ from django.views import generic
 from django.views.decorators.csrf import csrf_exempt
 
 from ckeditor_uploader import utils
-from ckeditor_uploader.backends import registry
+from ckeditor_uploader.backends import get_backend
 from ckeditor_uploader.forms import SearchForm
 from ckeditor_uploader.utils import storage
 
@@ -92,7 +92,7 @@ class ImageUploadView(generic.View):
         """
         uploaded_file = request.FILES["upload"]
 
-        backend = registry.get_backend()
+        backend = get_backend()
 
         ck_func_num = request.GET.get("CKEditorFuncNum")
         if ck_func_num:


### PR DESCRIPTION
Addresses #686

Honours known `CKEDITOR_IMAGE_BACKEND` keys, while emitting deprecation warnings.

Any attempts to register custom backends will simply result in an import error.

If the approach is solid, needs a few new tests (and updates to existing tests) before merging.