### PR TITLE
Fix overriding form field `kwargs`

### DIFF
--- a/ckeditor/fields.py
+++ b/ckeditor/fields.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.contrib.admin.options import FORMFIELD_FOR_DBFIELD_DEFAULTS
 from django.db import models
 
 from .widgets import CKEditorWidget
@@ -25,6 +26,12 @@ class RichTextField(models.TextField):
         }
         defaults.update(kwargs)
         return super().formfield(**defaults)
+
+
+# Makes sure that the `formfield()` method above doesn't receive the default `widget`
+# argument from the Django admin site, which would have overwritten our own widget with
+# an `AdminTextareaWidget`
+FORMFIELD_FOR_DBFIELD_DEFAULTS[RichTextField] = {}
 
 
 class RichTextFormField(forms.fields.CharField):

--- a/ckeditor/fields.py
+++ b/ckeditor/fields.py
@@ -17,12 +17,19 @@ class RichTextField(models.TextField):
             "config_name": self.config_name,
             "extra_plugins": self.extra_plugins,
             "external_plugin_resources": self.external_plugin_resources,
+            "widget": RichTextFormField.widget(
+                config_name=self.config_name,
+                extra_plugins=self.extra_plugins,
+                external_plugin_resources=self.external_plugin_resources,
+            ),
         }
         defaults.update(kwargs)
         return super().formfield(**defaults)
 
 
 class RichTextFormField(forms.fields.CharField):
+    widget = CKEditorWidget
+
     def __init__(
         self,
         config_name="default",
@@ -31,9 +38,12 @@ class RichTextFormField(forms.fields.CharField):
         *args,
         **kwargs
     ):
-        kwargs["widget"] = CKEditorWidget(
-            config_name=config_name,
-            extra_plugins=extra_plugins,
-            external_plugin_resources=external_plugin_resources,
-        )
-        super().__init__(*args, **kwargs)
+        defaults = {
+            "widget": self.widget(
+                config_name=config_name,
+                extra_plugins=extra_plugins,
+                external_plugin_resources=external_plugin_resources,
+            ),
+        }
+        defaults.update(kwargs)
+        super().__init__(*args, **defaults)

--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -54,6 +54,8 @@ class CKEditorWidget(forms.Textarea):
         **kwargs
     ):
         super().__init__(*args, **kwargs)
+
+        self.config_name = config_name
         # Setup config from defaults.
         self.config = DEFAULT_CONFIG.copy()
 
@@ -62,14 +64,14 @@ class CKEditorWidget(forms.Textarea):
         if configs:
             if isinstance(configs, dict):
                 # Make sure the config_name exists.
-                if config_name in configs:
-                    config = configs[config_name]
+                if self.config_name in configs:
+                    config = configs[self.config_name]
                     # Make sure the configuration is a dictionary.
                     if not isinstance(config, dict):
                         raise ImproperlyConfigured(
                             'CKEDITOR_CONFIGS["%s"] \
                                 setting must be a dictionary type.'
-                            % config_name
+                            % self.config_name
                         )
                     # Override defaults with settings config.
                     self.config.update(config)
@@ -77,7 +79,7 @@ class CKEditorWidget(forms.Textarea):
                     raise ImproperlyConfigured(
                         "No configuration named '%s' \
                             found in your CKEDITOR_CONFIGS setting."
-                        % config_name
+                        % self.config_name
                     )
             else:
                 raise ImproperlyConfigured(

--- a/ckeditor_demo/demo_application/forms.py
+++ b/ckeditor_demo/demo_application/forms.py
@@ -4,7 +4,7 @@ from ckeditor.fields import RichTextFormField
 from ckeditor.widgets import CKEditorWidget
 from ckeditor_uploader.fields import RichTextUploadingFormField
 from ckeditor_uploader.widgets import CKEditorUploadingWidget
-
+from .models import ExampleModel, ExampleNonUploadModel
 from .widgets import CkEditorMultiWidget
 
 
@@ -36,3 +36,34 @@ class CkEditorMultiWidgetForm(forms.Form):
             },
         ),
     )
+
+
+class ExampleModelForm(forms.ModelForm):
+    class Meta:
+        model = ExampleModel
+        fields = "__all__"
+
+
+class ExampleNonUploadModelForm(forms.ModelForm):
+    class Meta:
+        model = ExampleNonUploadModel
+        fields = "__all__"
+
+
+class ExampleModelOverriddenWidgetForm(forms.ModelForm):
+    class Meta:
+        model = ExampleModel
+        fields = "__all__"
+        widgets = {
+            "content": CKEditorUploadingWidget(
+                config_name="my-custom-toolbar",
+                extra_plugins=["someplugin", "anotherplugin"],
+                external_plugin_resources=[
+                    (
+                        "someplugin",
+                        "/static/path/to/someplugin/",
+                        "plugin.js",
+                    )
+                ],
+            ),
+        }

--- a/ckeditor_demo/demo_application/tests/test_fields.py
+++ b/ckeditor_demo/demo_application/tests/test_fields.py
@@ -1,0 +1,56 @@
+from unittest import expectedFailure
+
+from django.test import TestCase
+
+from ckeditor.fields import RichTextFormField
+from ckeditor.widgets import CKEditorWidget
+from ckeditor_uploader.fields import RichTextUploadingFormField
+from ckeditor_uploader.widgets import CKEditorUploadingWidget
+from ..forms import (
+    ExampleModelForm,
+    ExampleModelOverriddenWidgetForm,
+    ExampleNonUploadModelForm,
+)
+
+
+class ModelFieldAndFormFieldTestCase(TestCase):
+    def test_non_upload_model_form_contains_expected_formfield(self):
+        form = ExampleNonUploadModelForm()
+        form_field = form.fields["content"]
+        self.assertIs(type(form_field), RichTextFormField)
+        widget = form_field.widget
+        self.assertIs(type(widget), CKEditorWidget)
+        self.assertEqual(widget.config_name, "default")
+        self.assertEqual(widget.config.get("extraPlugins"), None)
+        self.assertListEqual(widget.external_plugin_resources, [])
+
+    def test_upload_model_form_contains_expected_formfield(self):
+        form = ExampleModelForm()
+        form_field = form.fields["content"]
+        self.assertIs(type(form_field), RichTextUploadingFormField)
+        widget = form_field.widget
+        self.assertIs(type(widget), CKEditorUploadingWidget)
+        self.assertEqual(widget.config_name, "default")
+        self.assertEqual(widget.config.get("extraPlugins"), None)
+        self.assertListEqual(widget.external_plugin_resources, [])
+
+    # Fails because `RichTextUploadingFormField` always overwrites the widget
+    @expectedFailure
+    def test_upload_model_form_with_overridden_widget_contains_expected_formfield(self):
+        form = ExampleModelOverriddenWidgetForm()
+        form_field = form.fields["content"]
+        self.assertIs(type(form_field), RichTextUploadingFormField)
+        widget = form_field.widget
+        self.assertIs(type(widget), CKEditorUploadingWidget)
+        self.assertEqual(widget.config_name, "my-custom-toolbar")
+        self.assertEqual(widget.config.get("extraPlugins"), "someplugin,anotherplugin")
+        self.assertListEqual(
+            widget.external_plugin_resources,
+            [
+                (
+                    "someplugin",
+                    "/static/path/to/someplugin/",
+                    "plugin.js",
+                )
+            ],
+        )

--- a/ckeditor_demo/demo_application/tests/test_fields.py
+++ b/ckeditor_demo/demo_application/tests/test_fields.py
@@ -1,4 +1,9 @@
+from http import HTTPStatus
+from unittest import expectedFailure
+
+from django.contrib.auth import get_user_model
 from django.test import TestCase
+from django.urls import reverse
 
 from ckeditor.fields import RichTextFormField
 from ckeditor.widgets import CKEditorWidget
@@ -14,20 +19,23 @@ from ..forms import (
 class ModelFieldAndFormFieldTestCase(TestCase):
     def test_non_upload_model_form_contains_expected_formfield(self):
         form = ExampleNonUploadModelForm()
-        form_field = form.fields["content"]
-        self.assertIs(type(form_field), RichTextFormField)
-        widget = form_field.widget
-        self.assertIs(type(widget), CKEditorWidget)
-        self.assertEqual(widget.config_name, "default")
-        self.assertEqual(widget.config.get("extraPlugins"), None)
-        self.assertListEqual(widget.external_plugin_resources, [])
+        self.assert_form_contains_expected_formfield_with_default_widget_options(
+            form, "content", RichTextFormField, CKEditorWidget
+        )
 
     def test_upload_model_form_contains_expected_formfield(self):
         form = ExampleModelForm()
-        form_field = form.fields["content"]
-        self.assertIs(type(form_field), RichTextUploadingFormField)
+        self.assert_form_contains_expected_formfield_with_default_widget_options(
+            form, "content", RichTextUploadingFormField, CKEditorUploadingWidget
+        )
+
+    def assert_form_contains_expected_formfield_with_default_widget_options(
+        self, form, field_name, expected_field_type, expected_widget_type
+    ):
+        form_field = form.fields[field_name]
+        self.assertIs(type(form_field), expected_field_type)
         widget = form_field.widget
-        self.assertIs(type(widget), CKEditorUploadingWidget)
+        self.assertIs(type(widget), expected_widget_type)
         self.assertEqual(widget.config_name, "default")
         self.assertEqual(widget.config.get("extraPlugins"), None)
         self.assertListEqual(widget.external_plugin_resources, [])
@@ -49,4 +57,29 @@ class ModelFieldAndFormFieldTestCase(TestCase):
                     "plugin.js",
                 )
             ],
+        )
+
+    @expectedFailure
+    def test_admin_model_forms_contain_expected_formfields(self):
+        superuser = get_user_model().objects.create_user(
+            username="superuser", is_superuser=True, is_staff=True
+        )
+        self.client.force_login(superuser)
+
+        response = self.client.get(
+            reverse("admin:demo_application_examplenonuploadmodel_add")
+        )
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+        form = response.context["adminform"].form
+        self.assert_form_contains_expected_formfield_with_default_widget_options(
+            form, "content", RichTextFormField, CKEditorWidget
+        )
+
+        response = self.client.get(reverse("admin:demo_application_examplemodel_add"))
+        self.assertEqual(response.status_code, HTTPStatus.OK)
+
+        form = response.context["adminform"].form
+        self.assert_form_contains_expected_formfield_with_default_widget_options(
+            form, "content", RichTextUploadingFormField, CKEditorUploadingWidget
         )

--- a/ckeditor_demo/demo_application/tests/test_fields.py
+++ b/ckeditor_demo/demo_application/tests/test_fields.py
@@ -1,5 +1,4 @@
 from http import HTTPStatus
-from unittest import expectedFailure
 
 from django.contrib.auth import get_user_model
 from django.test import TestCase
@@ -59,7 +58,6 @@ class ModelFieldAndFormFieldTestCase(TestCase):
             ],
         )
 
-    @expectedFailure
     def test_admin_model_forms_contain_expected_formfields(self):
         superuser = get_user_model().objects.create_user(
             username="superuser", is_superuser=True, is_staff=True

--- a/ckeditor_demo/demo_application/tests/test_fields.py
+++ b/ckeditor_demo/demo_application/tests/test_fields.py
@@ -1,5 +1,3 @@
-from unittest import expectedFailure
-
 from django.test import TestCase
 
 from ckeditor.fields import RichTextFormField
@@ -34,8 +32,6 @@ class ModelFieldAndFormFieldTestCase(TestCase):
         self.assertEqual(widget.config.get("extraPlugins"), None)
         self.assertListEqual(widget.external_plugin_resources, [])
 
-    # Fails because `RichTextUploadingFormField` always overwrites the widget
-    @expectedFailure
     def test_upload_model_form_with_overridden_widget_contains_expected_formfield(self):
         form = ExampleModelOverriddenWidgetForm()
         form_field = form.fields["content"]

--- a/ckeditor_demo/demo_application/tests/test_widget_context.py
+++ b/ckeditor_demo/demo_application/tests/test_widget_context.py
@@ -1,13 +1,11 @@
 from http import HTTPStatus
-from unittest import expectedFailure
 
 from django.test import TestCase
 from django.urls import reverse
 
 from ckeditor.widgets import json_encode
-
-from ..forms import CkEditorMultiWidgetForm
 from .utils import get_config, get_contexts_for_widgets
+from ..forms import CkEditorMultiWidgetForm
 
 
 class WidgetContextTestCase(TestCase):
@@ -81,7 +79,6 @@ class WidgetContextTestCase(TestCase):
             "template_name": "ckeditor/widget.html",
         }
 
-    @expectedFailure  # FIXME it really shouldn't be.
     def test_rendered_ckeditor_multi_widgets_contain_expected_context(self):
         response = self.client.get(reverse("ckeditor-multi-widget-form"))
         self.assertEqual(response.status_code, HTTPStatus.OK)

--- a/ckeditor_uploader/fields.py
+++ b/ckeditor_uploader/fields.py
@@ -1,3 +1,5 @@
+from django.contrib.admin.options import FORMFIELD_FOR_DBFIELD_DEFAULTS
+
 from ckeditor import fields
 from . import widgets
 
@@ -14,6 +16,14 @@ class RichTextUploadingField(fields.RichTextField):
         }
         defaults.update(kwargs)
         return super().formfield(**defaults)
+
+
+# Makes sure that the `formfield()` method above doesn't receive the default `widget`
+# argument from the Django admin site, which would have overwritten our own widget with
+# an `AdminTextareaWidget`
+# (This is not strictly necessary when a default for `RichTextField` is already added
+# in `ckeditor/fields.py`, but better to have here as well, in case something changes)
+FORMFIELD_FOR_DBFIELD_DEFAULTS[RichTextUploadingField] = {}
 
 
 class RichTextUploadingFormField(fields.RichTextFormField):

--- a/ckeditor_uploader/fields.py
+++ b/ckeditor_uploader/fields.py
@@ -1,27 +1,20 @@
-from django import forms
-
 from ckeditor import fields
-from ckeditor_uploader import widgets
+from . import widgets
 
 
 class RichTextUploadingField(fields.RichTextField):
     def formfield(self, **kwargs):
-        kwargs["form_class"] = RichTextUploadingFormField
-        return super().formfield(**kwargs)
+        defaults = {
+            "form_class": RichTextUploadingFormField,
+            "widget": RichTextUploadingFormField.widget(
+                config_name=self.config_name,
+                extra_plugins=self.extra_plugins,
+                external_plugin_resources=self.external_plugin_resources,
+            ),
+        }
+        defaults.update(kwargs)
+        return super().formfield(**defaults)
 
 
-class RichTextUploadingFormField(forms.fields.CharField):
-    def __init__(
-        self,
-        config_name="default",
-        extra_plugins=None,
-        external_plugin_resources=None,
-        *args,
-        **kwargs
-    ):
-        kwargs["widget"] = widgets.CKEditorUploadingWidget(
-            config_name=config_name,
-            extra_plugins=extra_plugins,
-            external_plugin_resources=external_plugin_resources,
-        )
-        super().__init__(*args, **kwargs)
+class RichTextUploadingFormField(fields.RichTextFormField):
+    widget = widgets.CKEditorUploadingWidget


### PR DESCRIPTION
This should provide a better fix for #708 (which was caused by a bug in #707), while also enabling code to override the `widget` keyword argument of `RichTextFormField` and `RichTextUploadingFormField`. Also added some tests for the mentioned bug.

*See each commit message for more details.*