### PR TITLE
Update README + `setup.py`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,18 @@
 Django CKEditor
 ===============
 
+.. image:: https://img.shields.io/pypi/v/django-ckeditor.svg
+   :target: https://pypi.python.org/pypi/django-ckeditor
+
+.. image:: https://img.shields.io/pypi/pyversions/django-ckeditor.svg
+   :target: https://pypi.org/project/django-ckeditor/
+
+.. image:: https://github.com/django-ckeditor/django-ckeditor/workflows/Tests/badge.svg
+   :target: https://github.com/django-ckeditor/django-ckeditor/actions
+
+.. image:: https://readthedocs.org/projects/django-ckeditor/badge/?version=latest&style=flat
+   :target: https://django-ckeditor.readthedocs.io/en/latest/
+
 **NOTICE: django-ckeditor 5 has backward incompatible code moves against 4.5.1.**
 
 

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,9 @@ Django CKEditor
 .. image:: https://img.shields.io/pypi/pyversions/django-ckeditor.svg
    :target: https://pypi.org/project/django-ckeditor/
 
+.. image:: https://img.shields.io/pypi/djversions/django-ckeditor.svg
+   :target: https://pypi.org/project/django-ckeditor/
+
 .. image:: https://github.com/django-ckeditor/django-ckeditor/workflows/Tests/badge.svg
    :target: https://github.com/django-ckeditor/django-ckeditor/actions
 

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,8 @@ setup(
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Framework :: Django",
+        "Framework :: Django :: 3.2",
+        "Framework :: Django :: 4.0",
         "Intended Audience :: Developers",
         "Topic :: Internet :: WWW/HTTP :: Dynamic Content",
     ],

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,10 @@ setup(
     author="Shaun Sephton & Piotr Malinski",
     author_email="riklaunim@gmail.com",
     url="https://github.com/django-ckeditor/django-ckeditor",
+    project_urls={
+        "Documentation": "https://django-ckeditor.readthedocs.io/en/latest/",
+        "Source": "https://github.com/django-ckeditor/django-ckeditor",
+    },
     packages=find_packages(exclude=["*.demo"]),
     zip_safe=False,
     install_requires=[


### PR DESCRIPTION
This adds `project_urls` to `setup.py` (see [the docs page](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)), and some badges to the README.

Note: The Django versions badge currently says "missing", but it will update with the versions from `setup.py` once deployed to PyPI (see [django-hosts' README](https://github.com/jazzband/django-hosts/blob/5.1/README.rst) for a working example).