### PR TITLE
avoid calling static() at import if CKEDITOR_BASEPATH is defined

### DIFF
--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -38,8 +38,8 @@ class CKEditorWidget(forms.Textarea):
                     "data-ckeditor-basepath": getattr(
                         settings,
                         "CKEDITOR_BASEPATH",
-                        static("ckeditor/ckeditor/"),
-                    ),
+                        None,
+                    ) or static("ckeditor/ckeditor/"),
                 },
             ),
             "ckeditor/ckeditor/ckeditor.js",


### PR DESCRIPTION
Currently, static("ckeditor/ckeditor") is called even with CKEDITOR_BASEPATH defined, which is unnecessary and messes up the functioning of s3manifestcollectstatic. This is a simple tweak to address that.