### PR TITLE
Fix the weight of the RichTextField (responsive)

### DIFF
--- a/ckeditor/configs.py
+++ b/ckeditor/configs.py
@@ -21,7 +21,7 @@ DEFAULT_CONFIG = {
     ],
     "toolbar": "Full",
     "height": 291,
-    "width": 835,
+    "width": "100%",
     "filebrowserWindowWidth": 940,
     "filebrowserWindowHeight": 725,
 }


### PR DESCRIPTION
We are using django-ckeditor but we found issue on the RichTextFiled
There is no any issue on big Screen Like Monitor greater than 21 inch but if we use smaller screen like Laptop or less than 15 inch monitor then there is issue of overlap with the django save button then i fixed it on our project and i want create pull request on your repo.
![image](https://user-images.githubusercontent.com/61644619/202717953-f1917acb-8d3d-4354-980f-465d1bd1ff3c.png)
