### PR TITLE
Fix ckeditor with django dark theme

### DIFF
--- a/ckeditor/static/ckeditor/ckeditor.css
+++ b/ckeditor/static/ckeditor/ckeditor.css
@@ -1,0 +1,16 @@
+/* Fix for Django dark theme background */
+/* See https://github.com/django-ckeditor/django-ckeditor/issues/670 */
+.cke_reset_all tr:nth-child(even),
+.cke_reset_all tr:nth-child(odd),
+.cke_reset_all .row-form-errors,
+.cke_reset_all tr:nth-child(even) .errorlist,
+.cke_reset_all tr:nth-child(odd) + .row-form-errors,
+.cke_reset_all tr:nth-child(odd) + .row-form-errors .errorlist {
+    background: inherit;
+}
+
+/* Fix for CKEditor source editor with Django dark theme */
+/* See https://github.com/django-ckeditor/django-ckeditor/issues/741 */
+textarea.cke_source {
+    color: revert;
+}

--- a/ckeditor/widgets.py
+++ b/ckeditor/widgets.py
@@ -86,6 +86,7 @@ class CKEditorWidget(forms.Textarea):
     @property
     def media(self):
         return Media(
+            css={"all": ["ckeditor/ckeditor.css"]},
             js=(
                 JS(
                     "ckeditor/ckeditor-init.js",


### PR DESCRIPTION
- Fix #670

  ![image](https://github.com/django-ckeditor/django-ckeditor/assets/23237214/f38f3c5c-3bac-4722-9623-32bc512c6c42)

  The source of the problem is that Django's styling overrides the background of some `<tr>` tags, so we could just override it with inherit.

  https://github.com/django/django/blob/ddb6506618ea52c6b20e97eefad03ed847a1e3de/django/contrib/admin/static/admin/css/base.css#L344-L353

- Fix #741

  ![image](https://github.com/django-ckeditor/django-ckeditor/assets/23237214/542b80b6-15ac-4c89-a7c8-2ffcf175f054)

  The source of the problem is that Django defines both `color` and `background-color` properties, but ckeditor only overrides the `background-color`.

  https://github.com/django/django/blob/ddb6506618ea52c6b20e97eefad03ed847a1e3de/django/contrib/admin/static/admin/css/base.css#L485-L493

  https://github.com/ckeditor/ckeditor4/blob/64452216e7785997770214c483c01ac2750e1e0a/skins/moono-lisa/presets.css#L20-L30